### PR TITLE
Add Django 1.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ env:
 - DJANGO="Django>=1.4,<1.5"
 - DJANGO="Django>=1.5,<1.6"
 - DJANGO="Django>=1.6,<1.7"
+- DJANGO="Django>=1.7,<1.8"
+matrix:
+  exclude:
+    - python: "2.6"
+      env: DJANGO="Django>=1.7,<1.8"
 install:
 - pip install $DJANGO
 script:

--- a/analytical/templatetags/clickmap.py
+++ b/analytical/templatetags/clickmap.py
@@ -8,13 +8,13 @@ import re
 
 from django.template import Library, Node, TemplateSyntaxError
 
-from analytical.utils import get_identity, is_internal_ip, disable_html, get_required_setting
+from analytical.utils import is_internal_ip, disable_html, get_required_setting
 
 
 CLICKMAP_TRACKER_ID_RE = re.compile(r'^\d+$')
 TRACKING_CODE = """
     <script type="text/javascript">
-    var clickmapConfig = {tracker: '%(tracker_id)', version:'2'};
+    var clickmapConfig = {tracker: '%(tracker_id)s', version:'2'};
     window.clickmapAsyncInit = function(){ __clickmap.init(clickmapConfig); };
     (function() { var _cmf = document.createElement('script'); _cmf.async = true;
     _cmf.src = document.location.protocol + '//www.clickmap.ch/tracker.js?t=';
@@ -46,12 +46,11 @@ def clickmap(parser, token):
 class ClickmapNode(Node):
     def __init__(self):
         self.tracker_id = get_required_setting('CLICKMAP_TRACKER_ID',
-                CLICKMAP_TRACKER_ID_RE,
-                "must be a (string containing) a number")
+                                               CLICKMAP_TRACKER_ID_RE,
+                                               "must be a (string containing) a number")
 
     def render(self, context):
-        html = TRACKING_CODE % {'portal_id': self.portal_id,
-                'domain': self.domain}
+        html = TRACKING_CODE % {'tracker_id': self.tracker_id}
         if is_internal_ip(context, 'CLICKMAP'):
             html = disable_html(html, 'Clickmap')
         return html

--- a/analytical/templatetags/hubspot.py
+++ b/analytical/templatetags/hubspot.py
@@ -27,6 +27,7 @@ TRACKING_CODE = """
 
 register = Library()
 
+
 @register.tag
 def hubspot(parser, token):
     """

--- a/analytical/tests/settings.py
+++ b/analytical/tests/settings.py
@@ -14,3 +14,6 @@ INSTALLED_APPS = [
 ]
 
 SECRET_KEY = 'testing'
+
+MIDDLEWARE_CLASSES=('django.middleware.common.CommonMiddleware',
+                    'django.middleware.csrf.CsrfViewMiddleware'),

--- a/analytical/tests/test_tag_chartbeat.py
+++ b/analytical/tests/test_tag_chartbeat.py
@@ -4,20 +4,18 @@ Tests for the Chartbeat template tags and filters.
 
 import re
 
-from django.conf import settings
 from django.contrib.sites.models import Site
 from django.http import HttpRequest
 from django.template import Context
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from analytical.templatetags.chartbeat import ChartbeatTopNode, \
         ChartbeatBottomNode
-from analytical.tests.utils import TagTestCase, with_apps, without_apps, \
-        override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
-@without_apps('django.contrib.sites')
 @override_settings(CHARTBEAT_USER_ID='12345')
 class ChartbeatTagTestCaseNoSites(TestCase):
     def test_rendering_setup_no_site(self):
@@ -25,7 +23,7 @@ class ChartbeatTagTestCaseNoSites(TestCase):
         self.assertTrue('var _sf_async_config={"uid": "12345"};' in r, r)
 
 
-@with_apps('django.contrib.sites')
+@override_settings(INSTALLED_APPS=('analytical', 'django.contrib.sites'))
 @override_settings(CHARTBEAT_USER_ID='12345')
 class ChartbeatTagTestCaseWithSites(TestCase):
     def setUp(self):
@@ -86,7 +84,7 @@ class ChartbeatTagTestCase(TagTestCase):
         self.assertTrue(re.search(
                 'var _sf_async_config={.*"domain": "test.com".*};', r), r)
 
-    @override_settings(CHARTBEAT_USER_ID=SETTING_DELETED)
+    @override_settings(CHARTBEAT_USER_ID=None)
     def test_no_user_id(self):
         self.assertRaises(AnalyticalException, ChartbeatBottomNode)
 

--- a/analytical/tests/test_tag_clickmap.py
+++ b/analytical/tests/test_tag_clickmap.py
@@ -4,14 +4,15 @@ Tests for the Clickmap template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.clickmap import ClickmapNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
 @override_settings(CLICKMAP_TRACKER_ID='12345')
-class ClickyTagTestCase(TagTestCase):
+class ClickmapTagTestCase(TagTestCase):
     """
     Tests for the ``clickmap`` template tag.
     """
@@ -24,7 +25,7 @@ class ClickyTagTestCase(TagTestCase):
         r = ClickmapNode().render(Context({}))
         self.assertTrue("tracker: '12345', version:'2'};" in r, r)
 
-    @override_settings(CLICKMAP_TRACKER_ID=SETTING_DELETED)
+    @override_settings(CLICKMAP_TRACKER_ID=None)
     def test_no_site_id(self):
         self.assertRaises(AnalyticalException, ClickmapNode)
 

--- a/analytical/tests/test_tag_clickmap.py
+++ b/analytical/tests/test_tag_clickmap.py
@@ -2,9 +2,6 @@
 Tests for the Clickmap template tags and filters.
 """
 
-import re
-
-from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
 
@@ -20,7 +17,7 @@ class ClickyTagTestCase(TagTestCase):
     """
 
     def test_tag(self):
-        r = self.render_tag('clicjmap', 'clickmap')
+        r = self.render_tag('clickmap', 'clickmap')
         self.assertTrue("tracker: '12345', version:'2'};" in r, r)
 
     def test_node(self):
@@ -33,7 +30,7 @@ class ClickyTagTestCase(TagTestCase):
 
     @override_settings(CLICKMAP_TRACKER_ID='abc')
     def test_wrong_site_id(self):
-        self.assertRaises(AnalyticalException, ClickyNode)
+        self.assertRaises(AnalyticalException, ClickmapNode)
 
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):

--- a/analytical/tests/test_tag_clicky.py
+++ b/analytical/tests/test_tag_clicky.py
@@ -7,9 +7,10 @@ import re
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.clicky import ClickyNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -31,7 +32,7 @@ class ClickyTagTestCase(TagTestCase):
         self.assertTrue('src="//in.getclicky.com/12345678ns.gif"' in r,
                 r)
 
-    @override_settings(CLICKY_SITE_ID=SETTING_DELETED)
+    @override_settings(CLICKY_SITE_ID=None)
     def test_no_site_id(self):
         self.assertRaises(AnalyticalException, ClickyNode)
 

--- a/analytical/tests/test_tag_crazy_egg.py
+++ b/analytical/tests/test_tag_crazy_egg.py
@@ -4,9 +4,10 @@ Tests for the Crazy Egg template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.crazy_egg import CrazyEggNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -24,7 +25,7 @@ class CrazyEggTagTestCase(TagTestCase):
         r = CrazyEggNode().render(Context())
         self.assertTrue('/1234/5678.js' in r, r)
 
-    @override_settings(CRAZY_EGG_ACCOUNT_NUMBER=SETTING_DELETED)
+    @override_settings(CRAZY_EGG_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
         self.assertRaises(AnalyticalException, CrazyEggNode)
 

--- a/analytical/tests/test_tag_gauges.py
+++ b/analytical/tests/test_tag_gauges.py
@@ -4,9 +4,10 @@ Tests for the Gauges template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.gauges import GaugesNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -53,7 +54,7 @@ class GaugesTagTestCase(TagTestCase):
 """,
                 GaugesNode().render(Context()))
 
-    @override_settings(GAUGES_SITE_ID=SETTING_DELETED)
+    @override_settings(GAUGES_SITE_ID=None)
     def test_no_account_number(self):
         self.assertRaises(AnalyticalException, GaugesNode)
 

--- a/analytical/tests/test_tag_google_analytics.py
+++ b/analytical/tests/test_tag_google_analytics.py
@@ -4,12 +4,12 @@ Tests for the Google Analytics template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.google_analytics import GoogleAnalyticsNode, \
         TRACK_SINGLE_DOMAIN, TRACK_MULTIPLE_DOMAINS, TRACK_MULTIPLE_SUBDOMAINS,\
         SCOPE_VISITOR, SCOPE_SESSION, SCOPE_PAGE
-from analytical.tests.utils import TestCase, TagTestCase, override_settings, \
-        without_apps, SETTING_DELETED
+from analytical.tests.utils import TestCase, TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -30,7 +30,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         self.assertTrue("_gaq.push(['_setAccount', 'UA-123456-7']);" in r, r)
         self.assertTrue("_gaq.push(['_trackPageview']);" in r, r)
 
-    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID=SETTING_DELETED)
+    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID=None)
     def test_no_property_id(self):
         self.assertRaises(AnalyticalException, GoogleAnalyticsNode)
 
@@ -104,11 +104,10 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         r = GoogleAnalyticsNode().render(Context())
         self.assertFalse("_gaq.push (['_gat._anonymizeIp']);" in r, r)
 
-@without_apps('django.contrib.sites')
 @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
         GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
-        GOOGLE_ANALYTICS_DOMAIN=SETTING_DELETED,
-        ANALYTICAL_DOMAIN=SETTING_DELETED)
+        GOOGLE_ANALYTICS_DOMAIN=None,
+        ANALYTICAL_DOMAIN=None)
 class NoDomainTestCase(TestCase):
     def test_exception_without_domain(self):
         context = Context()

--- a/analytical/tests/test_tag_gosquared.py
+++ b/analytical/tests/test_tag_gosquared.py
@@ -5,10 +5,11 @@ Tests for the GoSquared template tags and filters.
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.gosquared import GoSquaredNode
 from analytical.tests import override_settings
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -26,7 +27,7 @@ class GoSquaredTagTestCase(TagTestCase):
         r = GoSquaredNode().render(Context({}))
         self.assertTrue('GoSquared.acct = "ABC-123456-D";' in r, r)
 
-    @override_settings(GOSQUARED_SITE_TOKEN=SETTING_DELETED)
+    @override_settings(GOSQUARED_SITE_TOKEN=None)
     def test_no_token(self):
         self.assertRaises(AnalyticalException, GoSquaredNode)
 

--- a/analytical/tests/test_tag_hubspot.py
+++ b/analytical/tests/test_tag_hubspot.py
@@ -4,9 +4,10 @@ Tests for the HubSpot template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.hubspot import HubSpotNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -26,7 +27,7 @@ class HubSpotTagTestCase(TagTestCase):
         self.assertTrue("n.id=i;n.src='//js.hs-analytics.net/analytics/'+(Math.ceil(new Date()/r)*r)+'/1234.js';"
                         in r, r)
 
-    @override_settings(HUBSPOT_PORTAL_ID=SETTING_DELETED)
+    @override_settings(HUBSPOT_PORTAL_ID=None)
     def test_no_portal_id(self):
         self.assertRaises(AnalyticalException, HubSpotNode)
 

--- a/analytical/tests/test_tag_intercom.py
+++ b/analytical/tests/test_tag_intercom.py
@@ -5,11 +5,11 @@ Tests for the intercom template tags and filters.
 import datetime
 
 from django.contrib.auth.models import User, AnonymousUser
-from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.intercom import IntercomNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -41,7 +41,7 @@ class IntercomTagTestCase(TagTestCase):
 <script>(function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',intercomSettings);}else{var d=document;var i=function(){i.c(arguments)};i.q=[];i.c=function(args){i.q.push(args)};w.Intercom=i;function l(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://static.intercomcdn.com/intercom.v1.js';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);}if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})()</script>
 """, rendered_tag)
 
-    @override_settings(INTERCOM_APP_ID=SETTING_DELETED)
+    @override_settings(INTERCOM_APP_ID=None)
     def test_no_account_number(self):
         self.assertRaises(AnalyticalException, IntercomNode)
 

--- a/analytical/tests/test_tag_kiss_insights.py
+++ b/analytical/tests/test_tag_kiss_insights.py
@@ -4,9 +4,10 @@ Tests for the KISSinsights template tags and filters.
 
 from django.contrib.auth.models import User, AnonymousUser
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.kiss_insights import KissInsightsNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -25,11 +26,11 @@ class KissInsightsTagTestCase(TagTestCase):
         r = KissInsightsNode().render(Context())
         self.assertTrue("//s3.amazonaws.com/ki.js/12345/abc.js" in r, r)
 
-    @override_settings(KISS_INSIGHTS_ACCOUNT_NUMBER=SETTING_DELETED)
+    @override_settings(KISS_INSIGHTS_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
         self.assertRaises(AnalyticalException, KissInsightsNode)
 
-    @override_settings(KISS_INSIGHTS_SITE_CODE=SETTING_DELETED)
+    @override_settings(KISS_INSIGHTS_SITE_CODE=None)
     def test_no_site_code(self):
         self.assertRaises(AnalyticalException, KissInsightsNode)
 

--- a/analytical/tests/test_tag_kiss_metrics.py
+++ b/analytical/tests/test_tag_kiss_metrics.py
@@ -5,9 +5,10 @@ Tests for the KISSmetrics tags and filters.
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.kiss_metrics import KissMetricsNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -28,7 +29,7 @@ class KissMetricsTagTestCase(TagTestCase):
         self.assertTrue("//doug1izaerwt3.cloudfront.net/0123456789abcdef012345"
                 "6789abcdef01234567.1.js" in r, r)
 
-    @override_settings(KISS_METRICS_API_KEY=SETTING_DELETED)
+    @override_settings(KISS_METRICS_API_KEY=None)
     def test_no_api_key(self):
         self.assertRaises(AnalyticalException, KissMetricsNode)
 

--- a/analytical/tests/test_tag_mixpanel.py
+++ b/analytical/tests/test_tag_mixpanel.py
@@ -5,9 +5,10 @@ Tests for the Mixpanel tags and filters.
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.mixpanel import MixpanelNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -29,7 +30,7 @@ class MixpanelTagTestCase(TagTestCase):
                 "mixpanel.init('0123456789abcdef0123456789abcdef');" in r,
                 r)
 
-    @override_settings(MIXPANEL_API_TOKEN=SETTING_DELETED)
+    @override_settings(MIXPANEL_API_TOKEN=None)
     def test_no_token(self):
         self.assertRaises(AnalyticalException, MixpanelNode)
 

--- a/analytical/tests/test_tag_olark.py
+++ b/analytical/tests/test_tag_olark.py
@@ -4,9 +4,10 @@ Tests for the Olark template tags and filters.
 
 from django.contrib.auth.models import User, AnonymousUser
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.olark import OlarkNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -24,7 +25,7 @@ class OlarkTestCase(TagTestCase):
         r = OlarkNode().render(Context())
         self.assertTrue("olark.identify('1234-567-89-0123');" in r, r)
 
-    @override_settings(OLARK_SITE_ID=SETTING_DELETED)
+    @override_settings(OLARK_SITE_ID=None)
     def test_no_site_id(self):
         self.assertRaises(AnalyticalException, OlarkNode)
 

--- a/analytical/tests/test_tag_optimizely.py
+++ b/analytical/tests/test_tag_optimizely.py
@@ -4,9 +4,10 @@ Tests for the Optimizely template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.optimizely import OptimizelyNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -26,7 +27,7 @@ class OptimizelyTagTestCase(TagTestCase):
                 '<script src="//cdn.optimizely.com/js/1234567.js"></script>',
                 OptimizelyNode().render(Context()))
 
-    @override_settings(OPTIMIZELY_ACCOUNT_NUMBER=SETTING_DELETED)
+    @override_settings(OPTIMIZELY_ACCOUNT_NUMBER=None)
     def test_no_account_number(self):
         self.assertRaises(AnalyticalException, OptimizelyNode)
 

--- a/analytical/tests/test_tag_performable.py
+++ b/analytical/tests/test_tag_performable.py
@@ -5,9 +5,10 @@ Tests for the Performable template tags and filters.
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.performable import PerformableNode
-from analytical.tests.utils import TagTestCase, override_settings, SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -25,7 +26,7 @@ class PerformableTagTestCase(TagTestCase):
         r = PerformableNode().render(Context())
         self.assertTrue('/performable/pax/123ABC.js' in r, r)
 
-    @override_settings(PERFORMABLE_API_KEY=SETTING_DELETED)
+    @override_settings(PERFORMABLE_API_KEY=None)
     def test_no_api_key(self):
         self.assertRaises(AnalyticalException, PerformableNode)
 

--- a/analytical/tests/test_tag_piwik.py
+++ b/analytical/tests/test_tag_piwik.py
@@ -4,10 +4,10 @@ Tests for the Piwik template tags and filters.
 
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.piwik import PiwikNode
-from analytical.tests.utils import TagTestCase, override_settings, \
-    SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -38,11 +38,11 @@ class PiwikTagTestCase(TagTestCase):
         self.assertTrue(' ? "https" : "http") + "://example.com/piwik/";' in r,
                         r)
 
-    @override_settings(PIWIK_DOMAIN_PATH=SETTING_DELETED)
+    @override_settings(PIWIK_DOMAIN_PATH=None)
     def test_no_domain(self):
         self.assertRaises(AnalyticalException, PiwikNode)
 
-    @override_settings(PIWIK_SITE_ID=SETTING_DELETED)
+    @override_settings(PIWIK_SITE_ID=None)
     def test_no_siteid(self):
         self.assertRaises(AnalyticalException, PiwikNode)
 

--- a/analytical/tests/test_tag_reinvigorate.py
+++ b/analytical/tests/test_tag_reinvigorate.py
@@ -7,10 +7,10 @@ import re
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.reinvigorate import ReinvigorateNode
-from analytical.tests.utils import TagTestCase, override_settings, \
-        SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -28,7 +28,7 @@ class ReinvigorateTagTestCase(TagTestCase):
         r = ReinvigorateNode().render(Context({}))
         self.assertTrue('reinvigorate.track("12345-abcdefghij");' in r, r)
 
-    @override_settings(REINVIGORATE_TRACKING_ID=SETTING_DELETED)
+    @override_settings(REINVIGORATE_TRACKING_ID=None)
     def test_no_tracking_id(self):
         self.assertRaises(AnalyticalException, ReinvigorateNode)
 

--- a/analytical/tests/test_tag_snapengage.py
+++ b/analytical/tests/test_tag_snapengage.py
@@ -4,14 +4,14 @@ Tests for the SnapEngage template tags and filters.
 
 from django.contrib.auth.models import User, AnonymousUser
 from django.template import Context
+from django.test.utils import override_settings
 from django.utils import translation
 
 from analytical.templatetags.snapengage import SnapEngageNode, \
         BUTTON_STYLE_LIVE, BUTTON_STYLE_DEFAULT, BUTTON_STYLE_NONE, \
         BUTTON_LOCATION_LEFT, BUTTON_LOCATION_RIGHT, BUTTON_LOCATION_TOP, \
         BUTTON_LOCATION_BOTTOM, FORM_POSITION_TOP_LEFT
-from analytical.tests.utils import TagTestCase, override_settings, \
-        SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -41,7 +41,7 @@ class SnapEngageTestCase(TagTestCase):
             'SnapABug.addButton("ec329c69-0bf0-4db8-9b77-3f8150fb977e","0",'
             '"55%");' in r, r)
 
-    @override_settings(SNAPENGAGE_WIDGET_ID=SETTING_DELETED)
+    @override_settings(SNAPENGAGE_WIDGET_ID=None)
     def test_no_site_id(self):
         self.assertRaises(AnalyticalException, SnapEngageNode)
 

--- a/analytical/tests/test_tag_spring_metrics.py
+++ b/analytical/tests/test_tag_spring_metrics.py
@@ -7,10 +7,10 @@ import re
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.spring_metrics import SpringMetricsNode
-from analytical.tests.utils import TagTestCase, override_settings, \
-        SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -28,7 +28,7 @@ class SpringMetricsTagTestCase(TagTestCase):
         r = SpringMetricsNode().render(Context({}))
         self.assertTrue("_springMetq.push(['id', '12345678']);" in r, r)
 
-    @override_settings(SPRING_METRICS_TRACKING_ID=SETTING_DELETED)
+    @override_settings(SPRING_METRICS_TRACKING_ID=None)
     def test_no_site_id(self):
         self.assertRaises(AnalyticalException, SpringMetricsNode)
 

--- a/analytical/tests/test_tag_uservoice.py
+++ b/analytical/tests/test_tag_uservoice.py
@@ -2,13 +2,11 @@
 Tests for the UserVoice tags and filters.
 """
 
-from django.contrib.auth.models import User, AnonymousUser
-from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.uservoice import UserVoiceNode
-from analytical.tests.utils import TagTestCase, override_settings, \
-        SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -32,7 +30,7 @@ class UserVoiceTagTestCase(TagTestCase):
         r = self.render_tag('uservoice', 'uservoice')
         self.assertIn("widget.uservoice.com/abcdefghijklmnopqrst.js", r)
 
-    @override_settings(USERVOICE_WIDGET_KEY=SETTING_DELETED)
+    @override_settings(USERVOICE_WIDGET_KEY=None)
     def test_no_key(self):
         self.assertRaises(AnalyticalException, UserVoiceNode)
 

--- a/analytical/tests/test_tag_woopra.py
+++ b/analytical/tests/test_tag_woopra.py
@@ -5,10 +5,10 @@ Tests for the Woopra template tags and filters.
 from django.contrib.auth.models import User, AnonymousUser
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.templatetags.woopra import WoopraNode
-from analytical.tests.utils import TagTestCase, override_settings, \
-        SETTING_DELETED
+from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
 
@@ -26,7 +26,7 @@ class WoopraTagTestCase(TagTestCase):
         r = WoopraNode().render(Context({}))
         self.assertTrue('var woo_settings = {"domain": "example.com"};' in r, r)
 
-    @override_settings(WOOPRA_DOMAIN=SETTING_DELETED)
+    @override_settings(WOOPRA_DOMAIN=None)
     def test_no_domain(self):
         self.assertRaises(AnalyticalException, WoopraNode)
 

--- a/analytical/tests/test_utils.py
+++ b/analytical/tests/test_utils.py
@@ -3,41 +3,25 @@ Tests for the analytical.utils module.
 """
 
 from django.conf import settings
-from django.contrib.sites.models import Site
 from django.http import HttpRequest
 from django.template import Context
+from django.test.utils import override_settings
 
 from analytical.utils import (
     get_domain, is_internal_ip, get_required_setting, AnalyticalException)
-from analytical.tests.utils import (
-    TestCase, override_settings, with_apps, SETTING_DELETED)
+from analytical.tests.utils import TestCase
 
 
 class SettingDeletedTestCase(TestCase):
-    @override_settings(USER_ID=SETTING_DELETED)
-    def test_deleted_setting_raises_exception(self):
-        self.assertRaises(AttributeError, getattr, settings, "USER_ID")
 
-    @override_settings(USER_ID=1)
-    def test_only_disable_within_context_manager(self):
-        """
-        Make sure deleted settings returns once the block exits.
-        """
-        self.assertEqual(settings.USER_ID, 1)
-
-        with override_settings(USER_ID=SETTING_DELETED):
-            self.assertRaises(AttributeError, getattr, settings, "USER_ID")
-
-        self.assertEqual(settings.USER_ID, 1)
-
-    @override_settings(USER_ID=SETTING_DELETED)
+    @override_settings(USER_ID=None)
     def test_get_required_setting(self):
         """
         Make sure using get_required_setting fails in the right place.
         """
         # only available in python >= 2.7
         if hasattr(self, 'assertRaisesRegexp'):
-            with self.assertRaisesRegexp(AnalyticalException, "^USER_ID setting: not found$"):
+            with self.assertRaisesRegexp(AnalyticalException, "^USER_ID setting is set to None$"):
                 user_id = get_required_setting("USER_ID", "\d+", "invalid USER_ID")
         else:
             self.assertRaises(AnalyticalException,

--- a/analytical/tests/utils.py
+++ b/analytical/tests/utils.py
@@ -4,103 +4,8 @@ Testing utilities.
 
 from __future__ import with_statement
 
-import copy
-
-from django.conf import settings, UserSettingsHolder
-from django.core.management import call_command
-from django.db.models import loading
 from django.template import Template, Context, RequestContext
 from django.test.testcases import TestCase
-from django.utils.functional import wraps
-
-
-SETTING_DELETED = object()
-
-
-# Backported adapted from Django trunk (r16377)
-class override_settings(object):
-    """
-    Temporarily override Django settings.
-
-    Can be used as either a decorator on test classes/functions or as
-    a context manager inside test functions.
-
-    In either case it temporarily overrides django.conf.settings so
-    that you can test how code acts when certain settings are set to
-    certain values or deleted altogether with SETTING_DELETED.
-
-    >>> @override_settings(FOOBAR=42)
-    >>> class TestBaz(TestCase):
-    >>>     # settings.FOOBAR == 42 for all tests
-    >>>
-    >>>     @override_settings(FOOBAR=43)
-    >>>     def test_widget(self):
-    >>>         # settings.FOOBAR == 43 for just this test
-    >>>
-    >>>         with override_settings(FOOBAR=44):
-    >>>             # settings.FOOBAR == 44 just inside this block
-    >>>             pass
-    >>>
-    >>>         # settings.FOOBAR == 43 inside the test
-    """
-    def __init__(self, **kwargs):
-        self.options = kwargs
-        self.wrapped = settings._wrapped
-
-    def __enter__(self):
-        self.enable()
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.disable()
-
-    def __call__(self, test_func):
-        from django.test import TransactionTestCase
-        if isinstance(test_func, type) and issubclass(test_func, TransactionTestCase):
-            # When decorating a class, we need to construct a new class
-            # with the same name so that the test discovery tools can
-            # get a useful name.
-            def _pre_setup(innerself):
-                self.enable()
-                test_func._pre_setup(innerself)
-            def _post_teardown(innerself):
-                test_func._post_teardown(innerself)
-                self.disable()
-            inner = type(
-                test_func.__name__,
-                (test_func,),
-                {
-                    '_pre_setup': _pre_setup,
-                    '_post_teardown': _post_teardown,
-                    '__module__': test_func.__module__,
-                })
-        else:
-            @wraps(test_func)
-            def inner(*args, **kwargs):
-                with self:
-                    return test_func(*args, **kwargs)
-        return inner
-
-    def enable(self):
-        class OverrideSettingsHolder(UserSettingsHolder):
-            def __getattr__(self, name):
-                if name == "default_settings":
-                    return self.__dict__["default_settings"]
-                return getattr(self.default_settings, name)
-
-        override = OverrideSettingsHolder(copy.copy(settings._wrapped))
-        for key, new_value in self.options.items():
-            if new_value is SETTING_DELETED:
-                try:
-                    delattr(override.default_settings, key)
-                except AttributeError:
-                    pass
-            else:
-                setattr(override, key, new_value)
-        settings._wrapped = override
-
-    def disable(self):
-        settings._wrapped = self.wrapped
-
 
 def run_tests():
     """
@@ -109,28 +14,17 @@ def run_tests():
     Sets the return code to the number of failed tests.
     """
     import sys
-    from django.test.simple import DjangoTestSuiteRunner
-    runner = DjangoTestSuiteRunner()
+    import django
+    try:
+        django.setup()
+    except AttributeError:
+        pass
+    try:
+        from django.test.runner import DiscoverRunner as TestRunner
+    except ImportError:
+        from django.test.simple import DjangoTestSuiteRunner as TestRunner
+    runner = TestRunner()
     sys.exit(runner.run_tests(["analytical"]))
-
-
-def with_apps(*apps):
-    """
-    Class decorator that makes sure the passed apps are present in
-    INSTALLED_APPS.
-    """
-    apps_set = set(settings.INSTALLED_APPS)
-    apps_set.update(apps)
-    return override_settings(INSTALLED_APPS=list(apps_set))
-
-
-def without_apps(*apps):
-    """
-    Class decorator that makes sure the passed apps are not present in
-    INSTALLED_APPS.
-    """
-    apps_list = [a for a in settings.INSTALLED_APPS if a not in apps]
-    return override_settings(INSTALLED_APPS=apps_list)
 
 
 class TagTestCase(TestCase):

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -22,6 +22,8 @@ def get_required_setting(setting, value_re, invalid_msg):
         value = getattr(settings, setting)
     except AttributeError:
         raise AnalyticalException("%s setting: not found" % setting)
+    if value is None:
+        raise AnalyticalException("%s setting is set to None" % setting)
     value = str(value)
     if not value_re.search(value):
         raise AnalyticalException("%s setting: %s: '%s'"

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
     ],
     platforms = ['any'],
     url = 'http://github.com/jcassee/django-analytical',

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
         py2.6-django1.4,py2.6-django1.5,py2.6-django1.6,
-        py2.7-django1.4,py2.7-django1.5,py2.7-django1.6
+        py2.7-django1.4,py2.7-django1.5,py2.7-django1.6,
+        py2.7-django1.7
 
 [testenv]
 commands = python -Wall setup.py test
@@ -45,3 +46,7 @@ deps = Django>=1.6,<1.7
 [testenv:py2.7-django1.6]
 basepython = python2.7
 deps = Django>=1.6,<1.7
+
+[testenv:py2.7-django1.7]
+basepython = python2.7
+deps = Django>=1.7,<1.8


### PR DESCRIPTION
* Added Django 1.7 to tox/travis (confirmed tox works, guessing for travis).
* Test failures became apparent in clickmap which have been fixed.
* Removed override_settings to django function instead (also removed with/without_apps as rarely used), required for Django 1.7 as the code copied from django does not honor the new app loading system.