### PR TITLE
Adding python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
 - "2.6"
 - "2.7"
+- "3.3"
+- "3.4"
 env:
 - DJANGO="Django>=1.4,<1.5"
 - DJANGO="Django>=1.5,<1.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
   exclude:
     - python: "2.6"
       env: DJANGO="Django>=1.7,<1.8"
+    - python: "3.3"
+      env: DJANGO="Django>=1.4,<1.5"
+    - python: "3.4"
+      env: DJANGO="Django>=1.4,<1.5"
 install:
 - pip install $DJANGO
 script:

--- a/analytical/templatetags/analytical.py
+++ b/analytical/templatetags/analytical.py
@@ -75,7 +75,7 @@ def _load_template_nodes():
         module = _import_tag_module(path)
         try:
             module.contribute_to_analytical(add_node_cls)
-        except AnalyticalException, e:
+        except AnalyticalException as e:
             logger.debug("not loading tags from '%s': %s", path, e)
     for location in TAG_LOCATIONS:
         template_nodes[location] = sum((template_nodes[location][p]

--- a/analytical/tests/test_tag_intercom.py
+++ b/analytical/tests/test_tag_intercom.py
@@ -34,7 +34,7 @@ class IntercomTagTestCase(TagTestCase):
                 date_joined=now)
         }))
         # Because the json isn't predictably ordered, we can't just test the whole thing verbatim.
-        self.assertEquals("""
+        self.assertEqual("""
 <script id="IntercomSettingsScriptTag">
   window.intercomSettings = {"app_id": "1234567890abcdef0123456789", "created_at": 1397074500, "email": "test@example.com", "name": "Firstname Lastname"};
 </script>

--- a/analytical/tests/test_utils.py
+++ b/analytical/tests/test_utils.py
@@ -19,8 +19,13 @@ class SettingDeletedTestCase(TestCase):
         """
         Make sure using get_required_setting fails in the right place.
         """
-        # only available in python >= 2.7
-        if hasattr(self, 'assertRaisesRegexp'):
+
+        # available in python >= 3.2
+        if hasattr(self, 'assertRaisesRegex'):
+            with self.assertRaisesRegex(AnalyticalException, "^USER_ID setting is set to None$"):
+                user_id = get_required_setting("USER_ID", "\d+", "invalid USER_ID")
+        # available in python >= 2.7, deprecated in 3.2
+        elif hasattr(self, 'assertRaisesRegexp'):
             with self.assertRaisesRegexp(AnalyticalException, "^USER_ID setting is set to None$"):
                 user_id = get_required_setting("USER_ID", "\d+", "invalid USER_ID")
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -2,46 +2,34 @@
 envlist =
         py2.6-django1.4,py2.6-django1.5,py2.6-django1.6,
         py2.7-django1.4,py2.7-django1.5,py2.7-django1.6,
-        py2.7-django1.7
+        py2.7-django1.7,
+        py3.3-django1.4,py3.3-django1.5,py3.3-django1.6,
+        py3.3-django1.7,
+        py3.4-django1.4,py3.4-django1.5,py3.4-django1.6,
+        py3.4-django1.7,
 
 [testenv]
 commands = python -Wall setup.py test
 
-[testenv:py2.6-django1.2]
-basepython = python2.6
-deps = Django>=1.2,<1.3
-
-[testenv:py2.6-django1.3]
-basepython = python2.6
-deps = Django>=1.3,<1.4
-
 [testenv:py2.6-django1.4]
 basepython = python2.6
-deps = Django>=1.4,<1.5
-
-[testenv:py2.7-django1.2]
-basepython = python2.7
-deps = Django>=1.2,<1.3
-
-[testenv:py2.7-django1.3]
-basepython = python2.7
-deps = Django>=1.3,<1.4
-
-[testenv:py2.7-django1.4]
-basepython = python2.7
 deps = Django>=1.4,<1.5
 
 [testenv:py2.6-django1.5]
 basepython = python2.6
 deps = Django>=1.5,<1.6
 
-[testenv:py2.7-django1.5]
-basepython = python2.7
-deps = Django>=1.5,<1.6
-
 [testenv:py2.6-django1.6]
 basepython = python2.6
 deps = Django>=1.6,<1.7
+
+[testenv:py2.7-django1.4]
+basepython = python2.7
+deps = Django>=1.4,<1.5
+
+[testenv:py2.7-django1.5]
+basepython = python2.7
+deps = Django>=1.5,<1.6
 
 [testenv:py2.7-django1.6]
 basepython = python2.7
@@ -49,4 +37,28 @@ deps = Django>=1.6,<1.7
 
 [testenv:py2.7-django1.7]
 basepython = python2.7
+deps = Django>=1.7,<1.8
+
+[testenv:py3.3-django1.5]
+basepython = python3.3
+deps = Django>=1.7,<1.8
+
+[testenv:py3.3-django1.6]
+basepython = python3.3
+deps = Django>=1.6,<1.7
+
+[testenv:py3.3-django1.7]
+basepython = python3.3
+deps = Django>=1.7,<1.8
+
+[testenv:py3.4-django1.5]
+basepython = python3.4
+deps = Django>=1.7,<1.8
+
+[testenv:py3.4-django1.6]
+basepython = python3.4
+deps = Django>=1.6,<1.7
+
+[testenv:py3.4-django1.7]
+basepython = python3.4
 deps = Django>=1.7,<1.8

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,8 @@ envlist =
         py2.6-django1.4,py2.6-django1.5,py2.6-django1.6,
         py2.7-django1.4,py2.7-django1.5,py2.7-django1.6,
         py2.7-django1.7,
-        py3.3-django1.4,py3.3-django1.5,py3.3-django1.6,
-        py3.3-django1.7,
-        py3.4-django1.4,py3.4-django1.5,py3.4-django1.6,
-        py3.4-django1.7,
+        py3.3-django1.5,py3.3-django1.6,py3.3-django1.7,
+        py3.4-django1.5,py3.4-django1.6,py3.4-django1.7,
 
 [testenv]
 commands = python -Wall setup.py test


### PR DESCRIPTION
Fixed the exception problem that was presenting problems for python >= 3.0. Changed some testing assertions, where possible, that have been deprecated in new versions of python. All of the tox tests are passing, as are all builds in the Travis build matrix.