### PR TITLE
Fix flake8 complaints (except for templatetags and tests)

### DIFF
--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -8,7 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 
 HTML_COMMENT = "<!-- %(service)s disabled on internal IP " \
-        "address\n%(html)s\n-->"
+               "address\n%(html)s\n-->"
 
 
 def get_required_setting(setting, value_re, invalid_msg):
@@ -27,7 +27,7 @@ def get_required_setting(setting, value_re, invalid_msg):
     value = str(value)
     if not value_re.search(value):
         raise AnalyticalException("%s setting: %s: '%s'"
-                % (setting, invalid_msg, value))
+                                  % (setting, invalid_msg, value))
     return value
 
 

--- a/docs/_ext/local.py
+++ b/docs/_ext/local.py
@@ -1,26 +1,26 @@
 def setup(app):
     app.add_crossref_type(
-        directivename = "setting",
-        rolename      = "setting",
-        indextemplate = "pair: %s; setting",
+        directivename="setting",
+        rolename="setting",
+        indextemplate="pair: %s; setting",
     )
     app.add_crossref_type(
-        directivename = "templatetag",
-        rolename      = "ttag",
-        indextemplate = "pair: %s; template tag"
+        directivename="templatetag",
+        rolename="ttag",
+        indextemplate="pair: %s; template tag"
     )
     app.add_crossref_type(
-        directivename = "templatefilter",
-        rolename      = "tfilter",
-        indextemplate = "pair: %s; template filter"
+        directivename="templatefilter",
+        rolename="tfilter",
+        indextemplate="pair: %s; template filter"
     )
     app.add_crossref_type(
-        directivename = "fieldlookup",
-        rolename      = "lookup",
-        indextemplate = "pair: %s; field lookup type",
+        directivename="fieldlookup",
+        rolename="lookup",
+        indextemplate="pair: %s; field lookup type",
     )
     app.add_description_unit(
-        directivename = "decorator",
-        rolename      = "dec",
-        indextemplate = "pair: %s; function decorator",
+        directivename="decorator",
+        rolename="dec",
+        indextemplate="pair: %s; function decorator",
     )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,9 @@
 # This file is execfile()d with the current directory set to its containing
 # directory.
 
-import sys, os
+import os
+import sys
+
 sys.path.append(os.path.join(os.path.abspath('.'), '_ext'))
 sys.path.append(os.path.dirname(os.path.abspath('.')))
 
@@ -42,6 +44,6 @@ htmlhelp_basename = 'analyticaldoc'
 # -- Options for LaTeX output --------------------------------------------------
 
 latex_documents = [
-  ('index', 'django-analytical.tex', u'Documentation for django-analytical',
-   u'Joost Cassee', 'manual'),
+    ('index', 'django-analytical.tex', u'Documentation for django-analytical',
+     u'Joost Cassee', 'manual'),
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.append(os.path.dirname(os.path.abspath('.')))
 import analytical
 
 
-# -- General configuration -----------------------------------------------------
+# -- General configuration --------------------------------------------------
 
 project = u'django-analytical'
 copyright = u'2011, Joost Cassee <joost@cassee.net>'
@@ -31,17 +31,18 @@ pygments_style = 'sphinx'
 
 intersphinx_mapping = {
     'http://docs.python.org/2.7': None,
-    'http://docs.djangoproject.com/en/1.8': 'http://docs.djangoproject.com/en/1.8/_objects/',
+    'http://docs.djangoproject.com/en/1.8':
+        'http://docs.djangoproject.com/en/1.8/_objects/',
 }
 
 
-# -- Options for HTML output ---------------------------------------------------
+# -- Options for HTML output ------------------------------------------------
 
 html_theme = 'default'
 htmlhelp_basename = 'analyticaldoc'
 
 
-# -- Options for LaTeX output --------------------------------------------------
+# -- Options for LaTeX output -----------------------------------------------
 
 latex_documents = [
     ('index', 'django-analytical.tex', u'Documentation for django-analytical',

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,14 @@ cmdclass = {}
 
 try:
     from sphinx.setup_command import BuildDoc
+
     cmdclass['build_sphinx'] = BuildDoc
 except ImportError:
     pass
 
 try:
     from sphinx_pypi_upload import UploadDoc
+
     cmdclass['upload_sphinx'] = UploadDoc
 except ImportError:
     pass
@@ -34,7 +36,9 @@ class TestCommand(Command):
 
     def run(self):
         from analytical.tests.utils import run_tests
+
         run_tests()
+
 
 cmdclass['test'] = TestCommand
 
@@ -42,24 +46,25 @@ cmdclass['test'] = TestCommand
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 import analytical
 
 setup(
-    name = 'django-analytical',
-    version = analytical.__version__,
-    license = analytical.__license__,
-    description = 'Analytics service integration for Django projects',
-    long_description = read('README.rst'),
-    author = analytical.__author__,
-    author_email = analytical.__email__,
-    packages = [
+    name='django-analytical',
+    version=analytical.__version__,
+    license=analytical.__license__,
+    description='Analytics service integration for Django projects',
+    long_description=read('README.rst'),
+    author=analytical.__author__,
+    author_email=analytical.__email__,
+    packages=[
         'analytical',
         'analytical.templatetags',
         'analytical.tests',
         'analytical.tests.templatetags',
     ],
-    keywords = ['django', 'analytics'],
-    classifiers = [
+    keywords=['django', 'analytics'],
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
         'Framework :: Django',
@@ -72,11 +77,11 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
     ],
-    platforms = ['any'],
-    url = 'http://github.com/jcassee/django-analytical',
-    download_url = 'http://github.com/jcassee/django-analytical/archives/master',
-    cmdclass = cmdclass,
-    install_requires = [
+    platforms=['any'],
+    url='http://github.com/jcassee/django-analytical',
+    download_url='http://github.com/jcassee/django-analytical/archives/master',
+    cmdclass=cmdclass,
+    install_requires=[
         'Django>=1.4',
     ],
 )


### PR DESCRIPTION
These changes fix mainly whitespace complaints by `flake8` everywhere except in the `templatetags` und the `tests` folder, i.e.
```
$ flake8 --exclude=templatetags,tests
```
runs without complaints.