### PR TITLE
mark the package python 3 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
     ],
     platforms=['any'],
     url='http://github.com/jcassee/django-analytical',


### PR DESCRIPTION
Part of my confusion in #59 was to see no reference to python 3 in `setup.py` . Added
