### PR TITLE
Calculate coverage and send to Coveralls.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+source = analytical
+omit = analytical/tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.geany
 /.idea
 /.tox
+/.coverage
 
 /build
 /dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 install:
-  - pip install tox
+  - pip install coveralls tox
 script:
   - tox
 env:  # generate list with: $ tox -l | xargs -I ITEM echo "  - TOXENV="ITEM

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-analytical |latest-version|
 ==================================
 
-|travis-ci| |downloads| |license|
+|travis-ci| |coveralls| |downloads| |license|
 
 The django-analytical application integrates analytics services into a
 Django_ project.
@@ -29,6 +29,9 @@ an asynchronous version of the Javascript code if possible.
 .. |travis-ci| image:: https://travis-ci.org/jcassee/django-analytical.svg
    :alt: Build status
    :target: https://travis-ci.org/jcassee/django-analytical
+.. |coveralls| image:: https://coveralls.io/repos/jcassee/django-analytical/badge.svg
+   :alt: Test coverage
+   :target: https://coveralls.io/r/jcassee/django-analytical
 .. |downloads| image:: https://img.shields.io/pypi/dm/django-analytical.svg
    :alt: Monthly downloads from PyPI
    :target: https://pypi.python.org/pypi/django-analytical

--- a/tox.ini
+++ b/tox.ini
@@ -5,15 +5,19 @@ envlist =
     py{33,34}-django{15,16,17,18},
 
 [testenv]
-commands = python -Wall setup.py test
+commands =
+    coverage run setup.py test
+    coveralls
 basepython =
     py26: python2.6
     py27: python2.7
     py33: python3.3
     py34: python3.4
 deps =
+    coveralls
     django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
We have pretty great test coverage, so let's advertise that!

This change does drop the `-Wall` option to `python setup.py test`. I could not determine how to tell the `coverage` script how to pass it to `python`. Is that important?