### PR TITLE
Update link to Google's Site Speed documentation

### DIFF
--- a/docs/services/google_analytics.rst
+++ b/docs/services/google_analytics.rst
@@ -124,7 +124,7 @@ You can view page load times in the `Site Speed report`_ by setting the
 
 By default, page load times are not tracked.
 
-.. _`Site Speed report`: http://www.google.com/support/analyticshelp/bin/answer.py?answer=1205784&topic=1282106
+.. _`Site Speed report`: https://support.google.com/analytics/answer/1205784
 
 
 .. _google-analytics-internal-ips:


### PR DESCRIPTION
The old link just 404s at the moment.