### PR TITLE
Fix RemovedInDjango19Warning (django.utils.importlib)

### DIFF
--- a/analytical/templatetags/analytical.py
+++ b/analytical/templatetags/analytical.py
@@ -8,7 +8,10 @@ import logging
 
 from django import template
 from django.template import Node, TemplateSyntaxError
-from django.utils.importlib import import_module
+try:
+    from importlib import import_module
+except ImportError:  # Python 2.6
+    from django.utils.importlib import import_module
 from analytical.utils import AnalyticalException
 
 


### PR DESCRIPTION
Does away with the deprecation warning displayed by Django 1.8 (e.g. with a runserver).

The implementation is backward compatible. Django's `django.utils.importlib` is only needed for Python 2.6 (e.g. in combination with Django 1.6), because Python's `importlib` core library is not available for Python lower than 2.7+.