### PR TITLE
override internal ips with empty list

### DIFF
--- a/analytical/tests/test_utils.py
+++ b/analytical/tests/test_utils.py
@@ -72,6 +72,14 @@ class InternalIpTestCase(TestCase):
         context = Context()
         self.assertFalse(is_internal_ip(context))
 
+    @override_settings(INTERNAL_IPS=['1.1.1.1'])
+    @override_settings(ANALYTICAL_INTERNAL_IPS=[])
+    def test_render_analytical_internal_ips_override_when_empty(self):
+        req = HttpRequest()
+        req.META['REMOTE_ADDR'] = '1.1.1.1'
+        context = Context({'request': req})
+        self.assertFalse(is_internal_ip(context))
+
     @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
     def test_render_internal_ip(self):
         req = HttpRequest()

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -123,15 +123,15 @@ def is_internal_ip(context, prefix=None):
         if not remote_ip:
             return False
 
-        internal_ips = ''
+        internal_ips = None
         if prefix is not None:
-            internal_ips = getattr(settings, '%s_INTERNAL_IPS' % prefix, '')
-        if not internal_ips:
-            internal_ips = getattr(settings, 'ANALYTICAL_INTERNAL_IPS', '')
-        if not internal_ips:
-            internal_ips = getattr(settings, 'INTERNAL_IPS', '')
+            internal_ips = getattr(settings, '%s_INTERNAL_IPS' % prefix, None)
+        if internal_ips is None:
+            internal_ips = getattr(settings, 'ANALYTICAL_INTERNAL_IPS', None)
+        if internal_ips is None:
+            internal_ips = getattr(settings, 'INTERNAL_IPS', None)
 
-        return remote_ip in internal_ips
+        return remote_ip in (internal_ips or [])
     except (KeyError, AttributeError):
         return False
 


### PR DESCRIPTION
I wanted to be able to set `ANALYTICAL_INTERNAL_IPS=[]` on my development machine, however when the list is empty it doesn't properly override what is in `INTERNAL_IPS`. This PR aims to fix that.