### PR TITLE
support alternative username fields

### DIFF
--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -76,7 +76,10 @@ def get_identity(context, prefix=None, identity_func=None, user=None):
                 if identity_func is not None:
                     return identity_func(user)
                 else:
-                    return user.username
+                    try:
+                        return user.get_username()
+                    except AttributeError:  # Django < 1.5 fallback
+                        return user.username
         except (KeyError, AttributeError):
             pass
     return None

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ basepython =
 deps =
     coverage==3.7.1
     coveralls
+    py26: unittest2
     django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7


### PR DESCRIPTION
This change is to make `get_identity` work when using a custom user model with an alternative username field. It gracefully handles versions of Django that don't support alternative username fields.