### PR TITLE
Allow local host names for Piwik servers

### DIFF
--- a/analytical/templatetags/piwik.py
+++ b/analytical/templatetags/piwik.py
@@ -15,7 +15,7 @@ from analytical.utils import (is_internal_ip, disable_html,
 
 
 # domain name (characters separated by a dot), optional URI path, no slash
-DOMAINPATH_RE = re.compile(r'^(([^./?#@:]+\.)+[^./?#@:]+)+(/[^/?#@:]+)*$')
+DOMAINPATH_RE = re.compile(r'^(([^./?#@:]+\.)*[^./?#@:]+)+(/[^/?#@:]+)*$')
 
 # numeric ID
 SITEID_RE = re.compile(r'^\d+$')


### PR DESCRIPTION
A simple change to the regular expression safeguarding the definition of a Piwiki server URL. Required an actual, public server name (domain with top-level domain) earlier. Now this limitation has been removed (i.e. local server names such as `localhost` are allowed); longer server names are still checked for syntactical plausibility.

Closes #76