### PR TITLE
Move comment on Django support from README to history

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,11 +21,6 @@ set-up very simple, while allowing advanced users to customize tracking.
 Each service is set up as recommended by the services themselves, using
 an asynchronous version of the Javascript code if possible.
 
-Version 1.0.0 is the last to support Django < 1.7. Users of older django
-versions should stick to 1.0.0, and are encouraged to upgrade their setups.
-Starting with 2.0.0, dropping support for obsolete Django versions is not
-considered to be a backward-incompatible change.
-
 .. end docs include
 
 .. |latest-version| image:: https://img.shields.io/pypi/v/django-analytical.svg

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -10,6 +10,11 @@ version numbers.  Patch-level increments indicate bug fixes, minor
 version increments indicate new functionality and major version
 increments indicate backwards incompatible changes.
 
+Version 1.0.0 is the last to support Django < 1.7. Users of older django
+versions should stick to 1.0.0, and are encouraged to upgrade their setups.
+Starting with 2.0.0, dropping support for obsolete Django versions is not
+considered to be a backward-incompatible change.
+
 .. _`Semantic Versioning`: http://semver.org/
 
 .. include:: ../CHANGELOG.rst
@@ -29,4 +34,4 @@ Helping out
 .. include:: ../README.rst
     :start-after: .. start contribute include
     :end-before: .. end contribute include
-	 
+


### PR DESCRIPTION
I believe the paragraph on Django support is better placed in the History chapter of the documentation. Makes the README unnecessarily verbose.

BTW, I adore your clean structure (allowing both self-explaining files in the project root and inclusion in the docs) with AUTHORS, CHANGELOG, LICENSE.