### PR TITLE
Fix more code smells reported by Landscape

### DIFF
--- a/analytical/templatetags/google_analytics.py
+++ b/analytical/templatetags/google_analytics.py
@@ -9,9 +9,13 @@ import re
 from django.conf import settings
 from django.template import Library, Node, TemplateSyntaxError
 
-from analytical.utils import is_internal_ip, disable_html, \
-        get_required_setting, get_domain, AnalyticalException
-
+from analytical.utils import (
+    AnalyticalException,
+    disable_html,
+    get_domain,
+    get_required_setting,
+    is_internal_ip,
+)
 
 TRACK_SINGLE_DOMAIN = 1
 TRACK_MULTIPLE_SUBDOMAINS = 2
@@ -41,7 +45,7 @@ DOMAIN_CODE = "_gaq.push(['_setDomainName', '%s']);"
 NO_ALLOW_HASH_CODE = "_gaq.push(['_setAllowHash', false]);"
 ALLOW_LINKER_CODE = "_gaq.push(['_setAllowLinker', true]);"
 CUSTOM_VAR_CODE = "_gaq.push(['_setCustomVar', %(index)s, '%(name)s', " \
-        "'%(value)s', %(scope)s]);"
+                  "'%(value)s', %(scope)s]);"
 SITE_SPEED_CODE = "_gaq.push(['_trackPageLoadTime']);"
 ANONYMIZE_IP_CODE = "_gaq.push (['_gat._anonymizeIp']);"
 DEFAULT_SOURCE = ("'https://ssl' : 'http://www'", "'.google-analytics.com/ga.js'")
@@ -68,8 +72,8 @@ def google_analytics(parser, token):
 class GoogleAnalyticsNode(Node):
     def __init__(self):
         self.property_id = get_required_setting(
-                'GOOGLE_ANALYTICS_PROPERTY_ID', PROPERTY_ID_RE,
-                "must be a string looking like 'UA-XXXXXX-Y'")
+            'GOOGLE_ANALYTICS_PROPERTY_ID', PROPERTY_ID_RE,
+            "must be a string looking like 'UA-XXXXXX-Y'")
 
     def render(self, context):
         commands = self._get_domain_commands(context)
@@ -97,8 +101,8 @@ class GoogleAnalyticsNode(Node):
             domain = get_domain(context, 'google_analytics')
             if domain is None:
                 raise AnalyticalException(
-                        "tracking multiple domains with Google Analytics"
-                        " requires a domain name")
+                    "tracking multiple domains with Google Analytics"
+                    " requires a domain name")
             commands.append(DOMAIN_CODE % domain)
             commands.append(NO_ALLOW_HASH_CODE)
             if tracking_type == TRACK_MULTIPLE_DOMAINS:
@@ -118,7 +122,12 @@ class GoogleAnalyticsNode(Node):
                 scope = var[2]
             except IndexError:
                 scope = SCOPE_PAGE
-            commands.append(CUSTOM_VAR_CODE % locals())
+            commands.append(CUSTOM_VAR_CODE % {
+                'index': index,
+                'name': name,
+                'value': value,
+                'scope': scope,
+            })
         return commands
 
     def _get_other_commands(self, context):

--- a/analytical/templatetags/woopra.py
+++ b/analytical/templatetags/woopra.py
@@ -10,9 +10,13 @@ import re
 from django.conf import settings
 from django.template import Library, Node, TemplateSyntaxError
 
-from analytical.utils import get_identity, get_user_from_context, \
-        is_internal_ip, disable_html, get_required_setting
-
+from analytical.utils import (
+    disable_html,
+    get_identity,
+    get_required_setting,
+    get_user_from_context,
+    is_internal_ip,
+)
 
 DOMAIN_RE = re.compile(r'^\S+$')
 TRACKING_CODE = """
@@ -29,7 +33,6 @@ TRACKING_CODE = """
       })();
     </script>
 """
-
 
 register = Library()
 
@@ -51,8 +54,8 @@ def woopra(parser, token):
 class WoopraNode(Node):
     def __init__(self):
         self.domain = get_required_setting(
-                'WOOPRA_DOMAIN', DOMAIN_RE,
-                "must be a domain name")
+            'WOOPRA_DOMAIN', DOMAIN_RE,
+            "must be a domain name")
 
     def render(self, context):
         settings = self._get_settings(context)
@@ -67,12 +70,12 @@ class WoopraNode(Node):
         return html
 
     def _get_settings(self, context):
-        vars = {'domain': self.domain}
+        variables = {'domain': self.domain}
         try:
-            vars['idle_timeout'] = str(settings.WOOPRA_IDLE_TIMEOUT)
+            variables['idle_timeout'] = str(settings.WOOPRA_IDLE_TIMEOUT)
         except AttributeError:
             pass
-        return vars
+        return variables
 
     def _get_visitor(self, context):
         params = {}
@@ -84,7 +87,7 @@ class WoopraNode(Node):
             user = get_user_from_context(context)
             if user is not None and user.is_authenticated():
                 params['name'] = get_identity(
-                        context, 'woopra', self._identify, user)
+                    context, 'woopra', self._identify, user)
                 if user.email:
                     params['email'] = user.email
         return params


### PR DESCRIPTION
Fixes the two worst offenders, currently. With some additional PEP8 corrections (white space).

I know using `locals()` is maybe elegant, but explicit is better than implicit. Landscape agrees.