### PR TITLE
Add woopra to window for SPA analytics

### DIFF
--- a/analytical/templatetags/woopra.py
+++ b/analytical/templatetags/woopra.py
@@ -24,13 +24,8 @@ TRACKING_CODE = """
       var woo_settings = %(settings)s;
       var woo_visitor = %(visitor)s;
       !function(){var a,b,c,d=window,e=document,f=arguments,g="script",h=["config","track","trackForm","trackClick","identify","visit","push","call"],i=function(){var a,b=this,c=function(a){b[a]=function(){return b._e.push([a].concat(Array.prototype.slice.call(arguments,0))),b}};for(b._e=[],a=0;a<h.length;a++)c(h[a])};for(d.__woo=d.__woo||{},a=0;a<f.length;a++)d.__woo[f[a]]=d[f[a]]=d[f[a]]||new i;b=e.createElement(g),b.async=1,b.src="//static.woopra.com/js/w.js",c=e.getElementsByTagName(g)[0],c.parentNode.insertBefore(b,c)}("woopra");
-
-      // configure tracker
       woopra.config(woo_settings);
-
       woopra.identify(woo_visitor);
-
-      // track pageview
       woopra.track();
     </script>
 """

--- a/analytical/templatetags/woopra.py
+++ b/analytical/templatetags/woopra.py
@@ -23,14 +23,15 @@ TRACKING_CODE = """
      <script type="text/javascript">
       var woo_settings = %(settings)s;
       var woo_visitor = %(visitor)s;
-      (function(){
-        var wsc=document.createElement('script');
-        wsc.type='text/javascript';
-        wsc.src=document.location.protocol+'//static.woopra.com/js/woopra.js';
-        wsc.async=true;
-        var ssc = document.getElementsByTagName('script')[0];
-        ssc.parentNode.insertBefore(wsc, ssc);
-      })();
+      !function(){var a,b,c,d=window,e=document,f=arguments,g="script",h=["config","track","trackForm","trackClick","identify","visit","push","call"],i=function(){var a,b=this,c=function(a){b[a]=function(){return b._e.push([a].concat(Array.prototype.slice.call(arguments,0))),b}};for(b._e=[],a=0;a<h.length;a++)c(h[a])};for(d.__woo=d.__woo||{},a=0;a<f.length;a++)d.__woo[f[a]]=d[f[a]]=d[f[a]]||new i;b=e.createElement(g),b.async=1,b.src="//static.woopra.com/js/w.js",c=e.getElementsByTagName(g)[0],c.parentNode.insertBefore(b,c)}("woopra");
+
+      // configure tracker
+      woopra.config(woo_settings);
+
+      woopra.identify(woo_visitor);
+
+      // track pageview
+      woopra.track();
     </script>
 """
 


### PR DESCRIPTION
To track custom events, like SPA routing, the global variable `woopra` is needed in the browser. (e.g. https://github.com/angulartics/angulartics) 

I took the latest JavaScript snippet from https://www.woopra.com/docs/setup/javascript-tracking/#basic as the updated async source.

