### PR TITLE
Escape the '@' symbol in doc

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Version 2.2.0
 
 Version 2.1.0
 -------------
-* Support Rating@Mmail.ru (Nikolay Korotkiy)
+* Support Rating\@mail.ru (Nikolay Korotkiy)
 * Support Yandex.Metrica (Nikolay Korotkiy)
 * Add support for extra Google Analytics variables (Steve Schwarz)
 * Remove support for Reinvigorate (service shut down)

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Currently Supported Services
 * `Optimizely`_ A/B testing
 * `Performable`_ web analytics and landing pages
 * `Piwik`_ open source web analytics
-* `Rating@Mail.ru`_ web analytics
+* `Rating\@Mail.ru`_ web analytics
 * `SnapEngage`_ live chat
 * `Spring Metrics`_ conversion tracking
 * `UserVoice`_ user feedback and helpdesk
@@ -91,7 +91,7 @@ Currently Supported Services
 .. _`Optimizely`: http://www.optimizely.com/
 .. _`Performable`: http://www.performable.com/
 .. _`Piwik`: http://www.piwik.org/
-.. _`Rating@Mail.ru`: http://top.mail.ru/
+.. _`Rating\@Mail.ru`: http://top.mail.ru/
 .. _`SnapEngage`: http://www.snapengage.com/
 .. _`Spring Metrics`: http://www.springmetrics.com/
 .. _`UserVoice`: http://www.uservoice.com/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -172,7 +172,7 @@ settings required to enable each service are listed here:
     PIWIK_DOMAIN_PATH = 'your.piwik.server/optional/path'
     PIWIK_SITE_ID = '123'
 
-* :doc:`Rating@Mail.ru <services/rating_mailru>`::
+* :doc:`Rating\@Mail.ru <services/rating_mailru>`::
 
     RATING_MAILRU_COUNTER_ID = '1234567'
 

--- a/docs/services/rating_mailru.rst
+++ b/docs/services/rating_mailru.rst
@@ -1,10 +1,10 @@
 ===================================
-Rating@Mail.ru -- traffic analysis
+Rating\@Mail.ru -- traffic analysis
 ===================================
 
-`Rating@Mail.ru`_ is an analytics tool like as google analytics.
+`Rating\@Mail.ru`_ is an analytics tool like as google analytics.
 
-.. _`Rating@Mail.ru`: http://top.mail.ru/
+.. _`Rating\@Mail.ru`: http://top.mail.ru/
 
 
 .. rating-mailru-installation:
@@ -12,17 +12,17 @@ Rating@Mail.ru -- traffic analysis
 Installation
 ============
 
-To start using the Rating@Mail.ru integration, you must have installed the
+To start using the Rating\@Mail.ru integration, you must have installed the
 django-analytical package and have added the ``analytical`` application
 to :const:`INSTALLED_APPS` in your project :file:`settings.py` file.
 See :doc:`../install` for details.
 
-Next you need to add the Rating@Mail.ru template tag to your templates. This
+Next you need to add the Rating\@Mail.ru template tag to your templates. This
 step is only needed if you are not using the generic
 :ttag:`analytical.*` tags.  If you are, skip to
 :ref:`rating-mailru-configuration`.
 
-The Rating@Mail.ru counter code is inserted into templates using a template
+The Rating\@Mail.ru counter code is inserted into templates using a template
 tag.  Load the :mod:`rating_mailru` template tag library and insert the
 :ttag:`rating_mailru` tag.  Because every page that you want to track must
 have the tag, it is useful to add it to your base template.  Insert
@@ -42,7 +42,7 @@ the tag at the bottom of the HTML head::
 Configuration
 =============
 
-Before you can use the Rating@Mail.ru integration, you must first set
+Before you can use the Rating\@Mail.ru integration, you must first set
 your website counter ID.
 
 
@@ -51,7 +51,7 @@ your website counter ID.
 Setting the counter ID
 ----------------------
 
-Every website you track with Rating@Mail.ru gets its own counter ID,
+Every website you track with Rating\@Mail.ru gets its own counter ID,
 and the :ttag:`rating_mailru` tag will include it in the rendered
 Javascript code.  You can find the web counter ID on the overview page
 of your account.  Set :const:`RATING_MAILRU_COUNTER_ID` in the


### PR DESCRIPTION
Prevent 'Raiting&#64;Mail.ru' from appearing as mailto link.