### PR TITLE
Use protocol-relative URL for Piwik fallback img

### DIFF
--- a/analytical/templatetags/piwik.py
+++ b/analytical/templatetags/piwik.py
@@ -21,7 +21,6 @@ DOMAINPATH_RE = re.compile(r'^(([^./?#@:]+\.)*[^./?#@:]+)+(:[0-9]+)?(/[^/?#@:]+)
 SITEID_RE = re.compile(r'^\d+$')
 
 TRACKING_CODE = """
-<!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
   %(variables)s
@@ -35,7 +34,6 @@ TRACKING_CODE = """
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<!-- End Piwik Code -->
 <noscript><p><img src="//%(url)s/piwik.php?idsite=%(siteid)s" style="border:0;" alt="" /></p></noscript>
 """  # noqa
 

--- a/analytical/templatetags/piwik.py
+++ b/analytical/templatetags/piwik.py
@@ -21,19 +21,21 @@ DOMAINPATH_RE = re.compile(r'^(([^./?#@:]+\.)*[^./?#@:]+)+(:[0-9]+)?(/[^/?#@:]+)
 SITEID_RE = re.compile(r'^\d+$')
 
 TRACKING_CODE = """
+<!-- Piwik -->
 <script type="text/javascript">
   var _paq = _paq || [];
   %(variables)s
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
   (function() {
-    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://%(url)s/";
+    var u="//%(url)s/";
     _paq.push(['setTrackerUrl', u+'piwik.php']);
     _paq.push(['setSiteId', %(siteid)s]);
-    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0]; g.type='text/javascript';
-    g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
+<!-- End Piwik Code -->
 <noscript><p><img src="//%(url)s/piwik.php?idsite=%(siteid)s" style="border:0;" alt="" /></p></noscript>
 """  # noqa
 

--- a/analytical/templatetags/piwik.py
+++ b/analytical/templatetags/piwik.py
@@ -34,7 +34,7 @@ TRACKING_CODE = """
     g.defer=true; g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
-<noscript><p><img src="http://%(url)s/piwik.php?idsite=%(siteid)s" style="border:0;" alt="" /></p></noscript>
+<noscript><p><img src="//%(url)s/piwik.php?idsite=%(siteid)s" style="border:0;" alt="" /></p></noscript>
 """  # noqa
 
 VARIABLE_CODE = '_paq.push(["setCustomVariable", %(index)s, "%(name)s", "%(value)s", "%(scope)s"]);'  # noqa

--- a/analytical/tests/test_tag_piwik.py
+++ b/analytical/tests/test_tag_piwik.py
@@ -36,22 +36,19 @@ class PiwikTagTestCase(TagTestCase):
                        PIWIK_SITE_ID='345')
     def test_domain_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com/piwik/"' in r,
-                        r)
+        self.assertTrue('"//example.com/piwik/"' in r, r)
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234',
                        PIWIK_SITE_ID='345')
     def test_domain_port_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com:1234/";' in r,
-                        r)
+        self.assertTrue('"//example.com:1234/";' in r, r)
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234/piwik',
                        PIWIK_SITE_ID='345')
     def test_domain_port_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue('"//example.com:1234/piwik/"' in r,
-                        r)
+        self.assertTrue('"//example.com:1234/piwik/"' in r, r)
 
     @override_settings(PIWIK_DOMAIN_PATH=None)
     def test_no_domain(self):

--- a/analytical/tests/test_tag_piwik.py
+++ b/analytical/tests/test_tag_piwik.py
@@ -20,14 +20,14 @@ class PiwikTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue(' ? "https" : "http") + "://example.com/";' in r, r)
+        self.assertTrue('"//example.com/"' in r, r)
         self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
         self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
                         in r, r)
 
     def test_node(self):
         r = PiwikNode().render(Context({}))
-        self.assertTrue(' ? "https" : "http") + "://example.com/";' in r, r)
+        self.assertTrue('"//example.com/";' in r, r)
         self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
         self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
                         in r, r)
@@ -36,21 +36,21 @@ class PiwikTagTestCase(TagTestCase):
                        PIWIK_SITE_ID='345')
     def test_domain_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue(' ? "https" : "http") + "://example.com/piwik/";' in r,
+        self.assertTrue('"//example.com/piwik/"' in r,
                         r)
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234',
                        PIWIK_SITE_ID='345')
     def test_domain_port_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue(' ? "https" : "http") + "://example.com:1234/";' in r,
+        self.assertTrue('"//example.com:1234/";' in r,
                         r)
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com:1234/piwik',
                        PIWIK_SITE_ID='345')
     def test_domain_port_path_valid(self):
         r = self.render_tag('piwik', 'piwik')
-        self.assertTrue(' ? "https" : "http") + "://example.com:1234/piwik/";' in r,
+        self.assertTrue('"//example.com:1234/piwik/"' in r,
                         r)
 
     @override_settings(PIWIK_DOMAIN_PATH=None)

--- a/analytical/tests/test_tag_piwik.py
+++ b/analytical/tests/test_tag_piwik.py
@@ -22,14 +22,14 @@ class PiwikTagTestCase(TagTestCase):
         r = self.render_tag('piwik', 'piwik')
         self.assertTrue(' ? "https" : "http") + "://example.com/";' in r, r)
         self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="http://example.com/piwik.php?idsite=345"'
+        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
                         in r, r)
 
     def test_node(self):
         r = PiwikNode().render(Context({}))
         self.assertTrue(' ? "https" : "http") + "://example.com/";' in r, r)
         self.assertTrue("_paq.push(['setSiteId', 345]);" in r, r)
-        self.assertTrue('img src="http://example.com/piwik.php?idsite=345"'
+        self.assertTrue('img src="//example.com/piwik.php?idsite=345"'
                         in r, r)
 
     @override_settings(PIWIK_DOMAIN_PATH='example.com/piwik',


### PR DESCRIPTION
Avoids mixed content issues when using django-analytical on sites served
over HTTPS. Using a protocol-relative URL is also recommended in the
Piwik documentation: https://issues.piwik.org/344.

Fixes #96.