### PR TITLE
Fix holding config variable in database through proxy objects

### DIFF
--- a/analytical/tests/test_tag_uservoice.py
+++ b/analytical/tests/test_tag_uservoice.py
@@ -40,14 +40,7 @@ class UserVoiceTagTestCase(TagTestCase):
 
     @override_settings(USERVOICE_WIDGET_KEY='')
     def test_empty_key(self):
-        r = UserVoiceNode().render(Context())
-        self.assertEqual(r, "")
-
-    @override_settings(USERVOICE_WIDGET_KEY='')
-    def test_overridden_empty_key(self):
-        vars = {'uservoice_widget_key': 'bcdefghijklmnopqrstu'}
-        r = UserVoiceNode().render(Context(vars))
-        self.assertIn("widget.uservoice.com/bcdefghijklmnopqrstu.js", r)
+        self.assertRaises(AnalyticalException, UserVoiceNode)
 
     def test_overridden_key(self):
         vars = {'uservoice_widget_key': 'defghijklmnopqrstuvw'}

--- a/analytical/tests/test_utils.py
+++ b/analytical/tests/test_utils.py
@@ -29,11 +29,11 @@ class SettingDeletedTestCase(TestCase):
 
         # available in python >= 3.2
         if hasattr(self, 'assertRaisesRegex'):
-            with self.assertRaisesRegex(AnalyticalException, "^USER_ID setting is set to None$"):
+            with self.assertRaisesRegex(AnalyticalException, "^USER_ID setting is not set$"):
                 user_id = get_required_setting("USER_ID", "\d+", "invalid USER_ID")
         # available in python >= 2.7, deprecated in 3.2
         elif hasattr(self, 'assertRaisesRegexp'):
-            with self.assertRaisesRegexp(AnalyticalException, "^USER_ID setting is set to None$"):
+            with self.assertRaisesRegexp(AnalyticalException, "^USER_ID setting is not set$"):
                 user_id = get_required_setting("USER_ID", "\d+", "invalid USER_ID")
         else:
             self.assertRaises(AnalyticalException,

--- a/analytical/utils.py
+++ b/analytical/utils.py
@@ -21,8 +21,8 @@ def get_required_setting(setting, value_re, invalid_msg):
         value = getattr(settings, setting)
     except AttributeError:
         raise AnalyticalException("%s setting: not found" % setting)
-    if value is None:
-        raise AnalyticalException("%s setting is set to None" % setting)
+    if not value:
+        raise AnalyticalException("%s setting is not set" % setting)
     value = str(value)
     if not value_re.search(value):
         raise AnalyticalException("%s setting: %s: '%s'"


### PR DESCRIPTION
A config variable may not necessarily be None when not configured. Can be stored in the database with the help of proxy objects, which can  return the None value when accessed.
For example, to integrate with jazzband/django-constance.