### PR TITLE
Check PyPI package description generation w/ tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ matrix:
     - { python: 3.6, env: DJANGO=1.10 }
     - { python: 3.3, env: DJANGO=1.11 }
   include:
-    - { python: 2.7, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=flake8 }
+    - { python: 3.6, env: TOXENV=checkdocs }
 
 install:
   - pip install tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     py{27,34,35}-django110
     py{27,34,35,36}-django111
     flake8
+    checkdocs
 
 [testenv]
 commands =
@@ -23,8 +24,15 @@ deps =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals = sh
 
+[testenv:checkdocs]
+deps =
+    collective.checkdocs
+    pygments
+commands =
+    python setup.py -q sdist
+    python setup.py checkdocs
+
 [testenv:flake8]
-basepython = python2.7
 deps = flake8
 commands = flake8
 


### PR DESCRIPTION
Converting the README.rst to HTML sometimes fails on PyPI and causes unreadable package descriptions on PyPI. This PR adds a check to tox and Travis, which verifies that the package description on PyPI will be generated correctly.