### PR TITLE
Use more targeted approach for README conversion check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - { python: 3.3, env: DJANGO=1.11 }
   include:
     - { python: 3.6, env: TOXENV=flake8 }
-    - { python: 3.6, env: TOXENV=checkdocs }
+    - { python: 3.6, env: TOXENV=readme }
 
 install:
   - pip install tox-travis

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     py{27,34,35}-django110
     py{27,34,35,36}-django111
     flake8
-    checkdocs
+    readme
 
 [testenv]
 commands =
@@ -24,17 +24,13 @@ deps =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 whitelist_externals = sh
 
-[testenv:checkdocs]
-deps =
-    collective.checkdocs
-    pygments
-commands =
-    python setup.py -q sdist
-    python setup.py checkdocs
-
 [testenv:flake8]
 deps = flake8
 commands = flake8
+
+[testenv:readme]
+deps = readme_renderer
+commands = python setup.py check --restructuredtext --strict
 
 [travis:env]
 DJANGO =


### PR DESCRIPTION
With this change we use the somewhat dedicated approach for checking for a correct .rst -> .html conversion before packaging. Seen at https://github.com/jazzband/pip-tools/pull/608.