### PR TITLE
Fix the ordering of Google Analytics calls

### DIFF
--- a/analytical/templatetags/google_analytics.py
+++ b/analytical/templatetags/google_analytics.py
@@ -32,7 +32,6 @@ SETUP_CODE = """
 
       var _gaq = _gaq || [];
       _gaq.push(['_setAccount', '%(property_id)s']);
-      _gaq.push(['_trackPageview']);
       %(commands)s
       (function() {
         var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
@@ -44,6 +43,7 @@ SETUP_CODE = """
 """
 DOMAIN_CODE = "_gaq.push(['_setDomainName', '%s']);"
 NO_ALLOW_HASH_CODE = "_gaq.push(['_setAllowHash', false]);"
+TRACK_PAGE_VIEW = "_gaq.push(['_trackPageview']);"
 ALLOW_LINKER_CODE = "_gaq.push(['_setAllowLinker', true]);"
 CUSTOM_VAR_CODE = "_gaq.push(['_setCustomVar', %(index)s, '%(name)s', " \
                   "'%(value)s', %(scope)s]);"
@@ -87,6 +87,7 @@ class GoogleAnalyticsNode(Node):
         commands = self._get_domain_commands(context)
         commands.extend(self._get_custom_var_commands(context))
         commands.extend(self._get_other_commands(context))
+        commands.append(TRACK_PAGE_VIEW)
         if getattr(settings, 'GOOGLE_ANALYTICS_DISPLAY_ADVERTISING', False):
             source = DISPLAY_ADVERTISING_SOURCE
         else:

--- a/analytical/templatetags/google_analytics.py
+++ b/analytical/templatetags/google_analytics.py
@@ -48,11 +48,11 @@ ALLOW_LINKER_CODE = "_gaq.push(['_setAllowLinker', true]);"
 CUSTOM_VAR_CODE = "_gaq.push(['_setCustomVar', %(index)s, '%(name)s', " \
                   "'%(value)s', %(scope)s]);"
 SITE_SPEED_CODE = "_gaq.push(['_trackPageLoadTime']);"
-ANONYMIZE_IP_CODE = "_gaq.push (['_gat._anonymizeIp']);"
-SAMPLE_RATE_CODE = "_gaq.push (['_setSampleRate', '%s']);"
-SITE_SPEED_SAMPLE_RATE_CODE = "_gaq.push (['_setSiteSpeedSampleRate', '%s']);"
-SESSION_COOKIE_TIMEOUT_CODE = "_gaq.push (['_setSessionCookieTimeout', '%s']);"
-VISITOR_COOKIE_TIMEOUT_CODE = "_gaq.push (['_setVisitorCookieTimeout', '%s']);"
+ANONYMIZE_IP_CODE = "_gaq.push(['_gat._anonymizeIp']);"
+SAMPLE_RATE_CODE = "_gaq.push(['_setSampleRate', '%s']);"
+SITE_SPEED_SAMPLE_RATE_CODE = "_gaq.push(['_setSiteSpeedSampleRate', '%s']);"
+SESSION_COOKIE_TIMEOUT_CODE = "_gaq.push(['_setSessionCookieTimeout', '%s']);"
+VISITOR_COOKIE_TIMEOUT_CODE = "_gaq.push(['_setVisitorCookieTimeout', '%s']);"
 DEFAULT_SOURCE = ("'https://ssl' : 'http://www'", "'.google-analytics.com/ga.js'")
 DISPLAY_ADVERTISING_SOURCE = ("'https://' : 'http://'", "'stats.g.doubleclick.net/dc.js'")
 

--- a/analytical/tests/test_tag_google_analytics.py
+++ b/analytical/tests/test_tag_google_analytics.py
@@ -93,6 +93,7 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     def test_anonymize_ip(self):
         r = GoogleAnalyticsNode().render(Context())
         self.assertTrue("_gaq.push (['_gat._anonymizeIp']);" in r, r)
+        self.assertTrue(r.index('_gat._anonymizeIp') < r.index('_trackPageview'), r)
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=False)
     def test_anonymize_ip_not_present(self):

--- a/analytical/tests/test_tag_google_analytics.py
+++ b/analytical/tests/test_tag_google_analytics.py
@@ -92,23 +92,23 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=True)
     def test_anonymize_ip(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_gat._anonymizeIp']);" in r, r)
+        self.assertTrue("_gaq.push(['_gat._anonymizeIp']);" in r, r)
         self.assertTrue(r.index('_gat._anonymizeIp') < r.index('_trackPageview'), r)
 
     @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=False)
     def test_anonymize_ip_not_present(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertFalse("_gaq.push (['_gat._anonymizeIp']);" in r, r)
+        self.assertFalse("_gaq.push(['_gat._anonymizeIp']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=0.0)
     def test_set_sample_rate_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSampleRate', '0.00']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSampleRate', '0.00']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE='100.00')
     def test_set_sample_rate_max(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSampleRate', '100.00']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSampleRate', '100.00']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=-1)
     def test_exception_whenset_sample_rate_too_small(self):
@@ -123,12 +123,12 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
     def test_set_site_speed_sample_rate_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSiteSpeedSampleRate', '0.00']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSiteSpeedSampleRate', '0.00']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
     def test_set_site_speed_sample_rate_max(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSiteSpeedSampleRate', '100.00']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSiteSpeedSampleRate', '100.00']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
     def test_exception_whenset_site_speed_sample_rate_too_small(self):
@@ -143,12 +143,12 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT=0)
     def test_set_session_cookie_timeout_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSessionCookieTimeout', '0']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSessionCookieTimeout', '0']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT='10000')
     def test_set_session_cookie_timeout_as_string(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setSessionCookieTimeout', '10000']);" in r, r)
+        self.assertTrue("_gaq.push(['_setSessionCookieTimeout', '10000']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT=-1)
     def test_exception_when_set_session_cookie_timeout_too_small(self):
@@ -158,12 +158,12 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT=0)
     def test_set_visitor_cookie_timeout_min(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setVisitorCookieTimeout', '0']);" in r, r)
+        self.assertTrue("_gaq.push(['_setVisitorCookieTimeout', '0']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT='10000')
     def test_set_visitor_cookie_timeout_as_string(self):
         r = GoogleAnalyticsNode().render(Context())
-        self.assertTrue("_gaq.push (['_setVisitorCookieTimeout', '10000']);" in r, r)
+        self.assertTrue("_gaq.push(['_setVisitorCookieTimeout', '10000']);" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT=-1)
     def test_exception_when_set_visitor_cookie_timeout_too_small(self):


### PR DESCRIPTION
Currently, django-analytical renders the google analytics like in the following order:

```
_gaq.push(['_setAccount', 'UA-########-##']);
_gaq.push(['_trackPageview']);
_gaq.push (['_gat._anonymizeIp']);
```

It's a bit strange though to call `_anonymizeIp` after the `_trackPageview` call already happened.
This patch changes the ordering, to follow:

```
_gaq.push(['_setAccount', 'UA-########-##']);
_gaq.push(['_gat._anonymizeIp']);
_gaq.push(['_trackPageview']);
```

This is what every blog recommends doing.