### PR TITLE
docs: Piwik is now Matomo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Currently Supported Services
 * `Olark`_ visitor chat
 * `Optimizely`_ A/B testing
 * `Performable`_ web analytics and landing pages
-* `Piwik`_ open source web analytics
+* `Matomo (formerly Piwik)`_ open source web analytics
 * `Rating\@Mail.ru`_ web analytics
 * `SnapEngage`_ live chat
 * `Spring Metrics`_ conversion tracking
@@ -89,7 +89,7 @@ Currently Supported Services
 .. _`Olark`: http://www.olark.com/
 .. _`Optimizely`: http://www.optimizely.com/
 .. _`Performable`: http://www.performable.com/
-.. _`Piwik`: http://www.piwik.org/
+.. _`Matomo (formerly Piwik)`: https://matomo.org
 .. _`Rating\@Mail.ru`: http://top.mail.ru/
 .. _`SnapEngage`: http://www.snapengage.com/
 .. _`Spring Metrics`: http://www.springmetrics.com/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -171,7 +171,7 @@ settings required to enable each service are listed here:
 
     PERFORMABLE_API_KEY = '123abc'
 
-* :doc:`Piwik <services/piwik>`::
+* :doc:`Matomo (formerly Piwik) <services/piwik>`::
 
     PIWIK_DOMAIN_PATH = 'your.piwik.server/optional/path'
     PIWIK_SITE_ID = '123'

--- a/docs/services/piwik.rst
+++ b/docs/services/piwik.rst
@@ -1,5 +1,5 @@
 ==================================
-Piwik -- open source web analytics
+Matomo (formerly Piwik) -- open source web analytics
 ==================================
 
 Piwik_ is an open analytics platform currently used by individuals,


### PR DESCRIPTION
See [Piwik is now Matomo – Announcement](https://matomo.org/blog/2018/01/piwik-is-now-matomo/)