### PR TITLE
Enable Intercom for anonymous users

### DIFF
--- a/analytical/templatetags/intercom.py
+++ b/analytical/templatetags/intercom.py
@@ -74,16 +74,13 @@ class IntercomNode(Node):
         return params
 
     def render(self, context):
-        user = get_user_from_context(context)
         params = self._get_custom_attrs(context)
         params["app_id"] = self.app_id
         html = TRACKING_CODE % {
             "settings_json": json.dumps(params, sort_keys=True)
         }
 
-        if is_internal_ip(context, 'INTERCOM') \
-                or not user or not get_user_is_authenticated(user):
-            # Intercom is disabled for non-logged in users.
+        if is_internal_ip(context, 'INTERCOM'):
             html = disable_html(html, 'Intercom')
         return html
 


### PR DESCRIPTION
This removes the check in the code that limits the Intercom widget to authenticated users. I'm not sure why the check was there: Intercom is intended for use with both anonymous and authenticated users.

This also updates the Intercom tests to add a conventional `test_render_internal_ip`.