### PR TITLE
Support Intercom HMAC identity verification

### DIFF
--- a/analytical/templatetags/intercom.py
+++ b/analytical/templatetags/intercom.py
@@ -3,10 +3,14 @@ intercom.io template tags and filters.
 """
 
 from __future__ import absolute_import
+
+import hashlib
+import hmac
 import json
 import time
 import re
 
+from django.conf import settings
 from django.template import Library, Node, TemplateSyntaxError
 
 from analytical.utils import disable_html, get_required_setting, \
@@ -22,6 +26,34 @@ TRACKING_CODE = """
 """  # noqa
 
 register = Library()
+
+
+def _hashable_bytes(data):  # type: (AnyStr) -> bytes
+    """
+    Coerce strings to hashable bytes.
+    """
+    if isinstance(data, bytes):
+        return data
+    elif isinstance(data, str):
+        return data.encode('ascii')  # Fail on anything non-ASCII.
+    else:
+        raise TypeError(data)
+
+
+def intercom_user_hash(data):  # type: (AnyStr) -> Optional[str]
+    """
+    Return a SHA-256 HMAC `user_hash` as expected by Intercom, if configured.
+
+    Return None if the `INTERCOM_HMAC_SECRET_KEY` setting is not configured.
+    """
+    if getattr(settings, 'INTERCOM_HMAC_SECRET_KEY', None):
+        return hmac.new(
+            key=_hashable_bytes(settings.INTERCOM_HMAC_SECRET_KEY),
+            msg=_hashable_bytes(data),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
+    else:
+        return None
 
 
 @register.tag
@@ -72,6 +104,16 @@ class IntercomNode(Node):
                     user.date_joined.timetuple()))
         else:
             params['created_at'] = None
+
+        # Generate a user_hash HMAC to verify the user's identity, if configured.
+        # (If both user_id and email are present, the user_id field takes precedence.)
+        # See:
+        # https://www.intercom.com/help/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product
+        user_hash_data = params.get('user_id', params.get('email'))  # type: Optional[str]
+        if user_hash_data:
+            user_hash = intercom_user_hash(str(user_hash_data))  # type: Optional[str]
+            if user_hash is not None:
+                params.setdefault('user_hash', user_hash)
 
         return params
 

--- a/analytical/templatetags/intercom.py
+++ b/analytical/templatetags/intercom.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import hashlib
 import hmac
 import json
+import sys
 import time
 import re
 
@@ -26,6 +27,14 @@ TRACKING_CODE = """
 """  # noqa
 
 register = Library()
+
+
+def _timestamp(when):  # type: (datetime) -> float
+    """
+    Python 2 compatibility for `datetime.timestamp()`.
+    """
+    return (time.mktime(when.timetuple()) if sys.version_info < (3,) else
+            when.timestamp())
 
 
 def _hashable_bytes(data):  # type: (AnyStr) -> bytes
@@ -100,8 +109,7 @@ class IntercomNode(Node):
 
             params.setdefault('user_id', user.pk)
 
-            params['created_at'] = int(time.mktime(
-                    user.date_joined.timetuple()))
+            params['created_at'] = int(_timestamp(user.date_joined))
         else:
             params['created_at'] = None
 

--- a/analytical/templatetags/intercom.py
+++ b/analytical/templatetags/intercom.py
@@ -66,6 +66,8 @@ class IntercomNode(Node):
             if 'email' not in params and user.email:
                 params['email'] = user.email
 
+            params.setdefault('user_id', user.pk)
+
             params['created_at'] = int(time.mktime(
                     user.date_joined.timetuple()))
         else:

--- a/analytical/tests/test_tag_intercom.py
+++ b/analytical/tests/test_tag_intercom.py
@@ -9,7 +9,7 @@ from django.http import HttpRequest
 from django.template import Context
 from django.test.utils import override_settings
 
-from analytical.templatetags.intercom import IntercomNode, intercom_user_hash
+from analytical.templatetags.intercom import IntercomNode, intercom_user_hash, _timestamp
 from analytical.tests.utils import TagTestCase
 from analytical.utils import AnalyticalException
 
@@ -123,7 +123,7 @@ class IntercomTagTestCase(TagTestCase):
         )  # type: User
         attrs = IntercomNode()._get_custom_attrs(Context({'user': user}))
         self.assertEqual({
-            'created_at': int(user.date_joined.timestamp()),
+            'created_at': int(_timestamp(user.date_joined)),
             'email': 'test@example.com',
             'name': '',
             'user_hash': intercom_user_hash(str(user.pk)),

--- a/docs/services/intercom.rst
+++ b/docs/services/intercom.rst
@@ -120,6 +120,8 @@ Context variable       Description
 --------------------  -------------------------------------------
 ``intercom_email``      The visitor's email address.
 --------------------  -------------------------------------------
+``intercom_user_id``    The visitor's user id.
+--------------------  -------------------------------------------
 ``created_at``          The date the visitor created an account
 ====================  ===========================================
 
@@ -130,7 +132,7 @@ Context variable       Description
 Identifying authenticated users
 -------------------------------
 
-If you have not set the ``intercom_name`` or ``intercom_email`` variables
+If you have not set the ``intercom_name``, ``intercom_email``, or ``intercom_user_id`` variables
 explicitly, the username and email address of an authenticated user are
 passed to Intercom automatically.  See :ref:`identifying-visitors`.
 

--- a/docs/services/intercom.rst
+++ b/docs/services/intercom.rst
@@ -138,6 +138,23 @@ passed to Intercom automatically.  See :ref:`identifying-visitors`.
 
 .. _intercom-internal-ips:
 
+
+Verifying identified users
+--------------------------
+
+Intercom supports HMAC authentication of users identified by user ID or email, in order to prevent impersonation.
+For more information, see `Enable identity verification on your web product`_ in the Intercom documentation.
+
+To enable this, configure your Intercom account's HMAC secret key::
+
+    INTERCOM_HMAC_SECRET_KEY = 'XXXXXXXXXXXXXXXXXXXXXXX'
+
+(You can find this secret key under the "Identity verification" section of your Intercom account settings page.)
+
+.. _`Enable identity verification on your web product`: https://www.intercom.com/help/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product
+
+
+
 Internal IP addresses
 ---------------------
 


### PR DESCRIPTION
This adds support for Intercom's HMAC identity verification, as documented here:

https://www.intercom.com/help/configure-intercom-for-your-product-or-site/staying-secure/enable-identity-verification-on-your-web-product

This adds a new optional setting: `INTERCOM_HMAC_SECRET_KEY`

This also sets a default `user_id` field for Django-authenticated users (which is what the HMAC authenticates, falling back to the `email` field).