### PR TITLE
Basic support of Google analytics.js, #108

### DIFF
--- a/analytical/templatetags/analytical.py
+++ b/analytical/templatetags/analytical.py
@@ -23,6 +23,7 @@ TAG_MODULES = [
     'analytical.facebook_pixel',
     'analytical.gauges',
     'analytical.google_analytics',
+    'analytical.google_analytics_js',
     'analytical.gosquared',
     'analytical.hubspot',
     'analytical.intercom',

--- a/analytical/templatetags/google_analytics.py
+++ b/analytical/templatetags/google_analytics.py
@@ -1,5 +1,7 @@
 """
 Google Analytics template tags and filters.
+
+DEPRECATED
 """
 
 from __future__ import absolute_import

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -67,7 +67,7 @@ class GoogleAnalyticsJsNode(Node):
         import json
         create_fields = self._get_domain_fields(context)
         create_fields.update(self._get_other_create_fields(context))
-        commands.extend(self._get_custom_var_commands(context))
+        commands = self._get_custom_var_commands(context)
         commands.extend(self._get_other_commands(context))
         display_features = getattr(settings, 'GOOGLE_ANALYTICS_DISPLAY_ADVERTISING', False)
         html = SETUP_CODE.format(

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -113,11 +113,11 @@ class GoogleAnalyticsJsNode(Node):
                 raise AnalyticalException("'GOOGLE_ANALYTICS_SAMPLE_RATE' must be >= 0 and <= 100")
             other_fields['sampleRate'] = value
 
-        cookie_expires = getattr(settings, 'GOOGLE_ANALYTICS_COOKIE_EXPIRES', False)
+        cookie_expires = getattr(settings, 'GOOGLE_ANALYTICS_COOKIE_EXPIRATION', False)
         if cookie_expires is not False:
             value = int(decimal.Decimal(sessionCookieTimeout))
             if value < 0:
-                raise AnalyticalException("'GOOGLE_ANALYTICS_COOKIE_EXPIRES' must be >= 0")
+                raise AnalyticalException("'GOOGLE_ANALYTICS_COOKIE_EXPIRATION' must be >= 0")
             other_fields['cookieExpires'] = value
 
         return other_fields

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -131,6 +131,10 @@ class GoogleAnalyticsJsNode(Node):
         for _, var in params:
             name = var[0]
             value = var[1]
+            try:
+                float(value)
+            except ValueError:
+                value = "'{}'".format(value)
             commands.append(CUSTOM_VAR_CODE.format(
                 name=name,
                 value=value,

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -24,10 +24,10 @@ TRACK_MULTIPLE_DOMAINS = 3
 PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$')
 SETUP_CODE = """
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+(function(i,s,o,g,r,a,m){{i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){{
+(i[r].q=i[r].q||[]).push(arguments)}},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+}})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
 ga('create', '{property_id}', 'auto', {create_fields});
 {display_features}
@@ -115,7 +115,7 @@ class GoogleAnalyticsJsNode(Node):
 
         cookie_expires = getattr(settings, 'GOOGLE_ANALYTICS_COOKIE_EXPIRATION', False)
         if cookie_expires is not False:
-            value = int(decimal.Decimal(sessionCookieTimeout))
+            value = int(decimal.Decimal(cookie_expires))
             if value < 0:
                 raise AnalyticalException("'GOOGLE_ANALYTICS_COOKIE_EXPIRATION' must be >= 0")
             other_fields['cookieExpires'] = value

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -49,7 +49,7 @@ def google_analytics_js(parser, token):
 
     Renders Javascript code to track page visits.  You must supply
     your website property ID (as a string) in the
-    ``GOOGLE_ANALYTICS_PROPERTY_ID`` setting.
+    ``GOOGLE_ANALYTICS_JS_PROPERTY_ID`` setting.
     """
     bits = token.split_contents()
     if len(bits) > 1:
@@ -60,7 +60,7 @@ def google_analytics_js(parser, token):
 class GoogleAnalyticsJsNode(Node):
     def __init__(self):
         self.property_id = get_required_setting(
-            'GOOGLE_ANALYTICS_PROPERTY_ID', PROPERTY_ID_RE,
+            'GOOGLE_ANALYTICS_JS_PROPERTY_ID', PROPERTY_ID_RE,
             "must be a string looking like 'UA-XXXXXX-Y'")
 
     def render(self, context):

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -27,7 +27,7 @@ SETUP_CODE = """
 (function(i,s,o,g,r,a,m){{i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){{
 (i[r].q=i[r].q||[]).push(arguments)}},i[r].l=1*new Date();a=s.createElement(o),
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-}})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+}})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
 ga('create', '{property_id}', 'auto', {create_fields});
 {display_features}

--- a/analytical/templatetags/google_analytics_js.py
+++ b/analytical/templatetags/google_analytics_js.py
@@ -1,0 +1,151 @@
+"""
+Google Analytics template tags and filters, using the new analytics.js library.
+"""
+
+from __future__ import absolute_import
+
+import decimal
+import re
+from django.conf import settings
+from django.template import Library, Node, TemplateSyntaxError
+
+from analytical.utils import (
+    AnalyticalException,
+    disable_html,
+    get_domain,
+    get_required_setting,
+    is_internal_ip,
+)
+
+TRACK_SINGLE_DOMAIN = 1
+TRACK_MULTIPLE_SUBDOMAINS = 2
+TRACK_MULTIPLE_DOMAINS = 3
+
+PROPERTY_ID_RE = re.compile(r'^UA-\d+-\d+$')
+SETUP_CODE = """
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', '{property_id}', 'auto', {create_fields});
+{display_features}
+ga('send', 'pageview');
+{commands}
+</script>
+"""
+REQUIRE_DISPLAY_FEATURES = "ga('require', 'displayfeatures');"
+CUSTOM_VAR_CODE = "ga('set', '{name}', {value});"
+ANONYMIZE_IP_CODE = "ga('set', 'anonymizeIp', true);"
+
+register = Library()
+
+
+@register.tag
+def google_analytics_js(parser, token):
+    """
+    Google Analytics tracking template tag.
+
+    Renders Javascript code to track page visits.  You must supply
+    your website property ID (as a string) in the
+    ``GOOGLE_ANALYTICS_PROPERTY_ID`` setting.
+    """
+    bits = token.split_contents()
+    if len(bits) > 1:
+        raise TemplateSyntaxError("'%s' takes no arguments" % bits[0])
+    return GoogleAnalyticsJsNode()
+
+
+class GoogleAnalyticsJsNode(Node):
+    def __init__(self):
+        self.property_id = get_required_setting(
+            'GOOGLE_ANALYTICS_PROPERTY_ID', PROPERTY_ID_RE,
+            "must be a string looking like 'UA-XXXXXX-Y'")
+
+    def render(self, context):
+        import json
+        create_fields = self._get_domain_fields(context)
+        create_fields.update(self._get_other_create_fields(context))
+        commands.extend(self._get_custom_var_commands(context))
+        commands.extend(self._get_other_commands(context))
+        display_features = getattr(settings, 'GOOGLE_ANALYTICS_DISPLAY_ADVERTISING', False)
+        html = SETUP_CODE.format(
+            property_id=self.property_id,
+            create_fields=json.dumps(create_fields),
+            display_features=REQUIRE_DISPLAY_FEATURES if display_features else '',
+            commands=" ".join(commands),
+        )
+        if is_internal_ip(context, 'GOOGLE_ANALYTICS'):
+            html = disable_html(html, 'Google Analytics')
+        return html
+
+    def _get_domain_fields(self, context):
+        domain_fields = {}
+        tracking_type = getattr(settings, 'GOOGLE_ANALYTICS_TRACKING_STYLE', TRACK_SINGLE_DOMAIN)
+        if tracking_type == TRACK_SINGLE_DOMAIN:
+            pass
+        else:
+            domain = get_domain(context, 'google_analytics')
+            if domain is None:
+                raise AnalyticalException(
+                    "tracking multiple domains with Google Analytics requires a domain name")
+            domain_fields['legacyCookieDomain'] = domain
+            if tracking_type == TRACK_MULTIPLE_DOMAINS:
+                domain_fields['allowLinker'] = True
+        return domain_fields
+
+    def _get_other_create_fields(self, context):
+        other_fields = {}
+
+        site_speed_sample_rate = getattr(settings, 'GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE', False)
+        if site_speed_sample_rate is not False:
+            value = int(decimal.Decimal(site_speed_sample_rate))
+            if not 0 <= value <= 100:
+                raise AnalyticalException(
+                    "'GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE' must be >= 0 and <= 100")
+            other_fields['siteSpeedSampleRate'] = value
+
+        sample_rate = getattr(settings, 'GOOGLE_ANALYTICS_SAMPLE_RATE', False)
+        if sample_rate is not False:
+            value = int(decimal.Decimal(sample_rate))
+            if not 0 <= value <= 100:
+                raise AnalyticalException("'GOOGLE_ANALYTICS_SAMPLE_RATE' must be >= 0 and <= 100")
+            other_fields['sampleRate'] = value
+
+        cookie_expires = getattr(settings, 'GOOGLE_ANALYTICS_COOKIE_EXPIRES', False)
+        if cookie_expires is not False:
+            value = int(decimal.Decimal(sessionCookieTimeout))
+            if value < 0:
+                raise AnalyticalException("'GOOGLE_ANALYTICS_COOKIE_EXPIRES' must be >= 0")
+            other_fields['cookieExpires'] = value
+
+        return other_fields
+
+    def _get_custom_var_commands(self, context):
+        values = (
+            context.get('google_analytics_var%s' % i) for i in range(1, 6)
+        )
+        params = [(i, v) for i, v in enumerate(values, 1) if v is not None]
+        commands = []
+        for _, var in params:
+            name = var[0]
+            value = var[1]
+            commands.append(CUSTOM_VAR_CODE.format(
+                name=name,
+                value=value,
+            ))
+        return commands
+
+    def _get_other_commands(self, context):
+        commands = []
+
+        if getattr(settings, 'GOOGLE_ANALYTICS_ANONYMIZE_IP', False):
+            commands.append(ANONYMIZE_IP_CODE)
+
+        return commands
+
+
+def contribute_to_analytical(add_node):
+    GoogleAnalyticsJsNode()  # ensure properly configured
+    add_node('head_bottom', GoogleAnalyticsJsNode)

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -21,11 +21,19 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
 
     def test_tag(self):
         r = self.render_tag('google_analytics_js', 'google_analytics_js')
+        self.assertTrue("""(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r, r)
         self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
         self.assertTrue("ga('send', 'pageview');" in r, r)
 
     def test_node(self):
         r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("""(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');""" in r, r)
         self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
         self.assertTrue("ga('send', 'pageview');" in r, r)
 

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -41,27 +41,28 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_subdomains(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'legacyCookieDomain': 'example.com'}" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"legacyCookieDomain": "example.com"}""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_domains(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'legacyCookieDomain': 'example.com'," in r, r)
-        self.assertTrue("'allowLinker': true});" in r, r)
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {" in r, r)
+        self.assertTrue('"legacyCookieDomain": "example.com"' in r, r)
+        self.assertTrue('"allowLinker\": true' in r, r)
 
     def test_custom_vars(self):
         context = Context({
             'google_analytics_var1': ('test1', 'foo'),
             'google_analytics_var2': ('test2', 'bar'),
-            'google_analytics_var4': ('test4', 'baz'),
-            'google_analytics_var5': ('test5', 'qux'),
+            'google_analytics_var4': ('test4', 1),
+            'google_analytics_var5': ('test5', 2.2),
         })
         r = GoogleAnalyticsJsNode().render(context)
         self.assertTrue("ga('set', 'test1', 'foo');" in r, r)
         self.assertTrue("ga('set', 'test2', 'bar');" in r, r)
-        self.assertTrue("ga('set', 'test4', 'baz');" in r, r)
-        self.assertTrue("ga('set', 'test5', 'qux');" in r, r)
+        self.assertTrue("ga('set', 'test4', 1);" in r, r)
+        self.assertTrue("ga('set', 'test5', 2.2);" in r, r)
 
     def test_display_advertising(self):
         with override_settings(GOOGLE_ANALYTICS_DISPLAY_ADVERTISING=True):
@@ -93,12 +94,12 @@ ga('send', 'pageview');""" in r, r)
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=0.0)
     def test_set_sample_rate_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'sampleRate', 0});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"sampleRate": 0});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE='100.00')
     def test_set_sample_rate_max(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'sampleRate', 100});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"sampleRate": 100});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=-1)
     def test_exception_whenset_sample_rate_too_small(self):
@@ -113,12 +114,12 @@ ga('send', 'pageview');""" in r, r)
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
     def test_set_site_speed_sample_rate_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'siteSpeedSampleRate': 0});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 0});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
     def test_set_site_speed_sample_rate_max(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'siteSpeedSampleRate': 100});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 100});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
     def test_exception_whenset_site_speed_sample_rate_too_small(self):
@@ -131,17 +132,17 @@ ga('send', 'pageview');""" in r, r)
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=0)
-    def test_set_session_cookie_timeout_min(self):
+    def test_set_cookie_expiration_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires'; 0});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 0});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION='10000')
-    def test_set_session_cookie_timeout_as_string(self):
+    def test_set_cookie_expiration_as_string(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires': 10000});" in r, r)
+        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 10000});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=-1)
-    def test_exception_when_set_session_cookie_timeout_too_small(self):
+    def test_exception_when_set_cookie_expiration_too_small(self):
         context = Context()
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
 

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -41,7 +41,8 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
     def test_track_multiple_subdomains(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"legacyCookieDomain": "example.com"}""" in r, r)
+        self.assertTrue(
+            """ga('create', 'UA-123456-7', 'auto', {"legacyCookieDomain": "example.com"}""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
                        GOOGLE_ANALYTICS_DOMAIN='example.com')
@@ -114,12 +115,14 @@ ga('send', 'pageview');""" in r, r)
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
     def test_set_site_speed_sample_rate_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 0});""" in r, r)
+        self.assertTrue(
+            """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 0});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
     def test_set_site_speed_sample_rate_max(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 100});""" in r, r)
+        self.assertTrue(
+            """ga('create', 'UA-123456-7', 'auto', {"siteSpeedSampleRate": 100});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
     def test_exception_whenset_site_speed_sample_rate_too_small(self):
@@ -139,7 +142,8 @@ ga('send', 'pageview');""" in r, r)
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION='10000')
     def test_set_cookie_expiration_as_string(self):
         r = GoogleAnalyticsJsNode().render(Context())
-        self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 10000});""" in r, r)
+        self.assertTrue(
+            """ga('create', 'UA-123456-7', 'auto', {"cookieExpires": 10000});""" in r, r)
 
     @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=-1)
     def test_exception_when_set_cookie_expiration_too_small(self):

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -12,7 +12,7 @@ from analytical.tests.utils import TestCase, TagTestCase
 from analytical.utils import AnalyticalException
 
 
-@override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
+@override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='UA-123456-7',
                    GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_SINGLE_DOMAIN)
 class GoogleAnalyticsTagTestCase(TagTestCase):
     """
@@ -29,11 +29,11 @@ class GoogleAnalyticsTagTestCase(TagTestCase):
         self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
         self.assertTrue("ga('send', 'pageview');" in r, r)
 
-    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID=None)
+    @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID=None)
     def test_no_property_id(self):
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
 
-    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='wrong')
+    @override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='wrong')
     def test_wrong_property_id(self):
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
 
@@ -147,7 +147,7 @@ ga('send', 'pageview');""" in r, r)
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
 
 
-@override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
+@override_settings(GOOGLE_ANALYTICS_JS_PROPERTY_ID='UA-123456-7',
                    GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
                    GOOGLE_ANALYTICS_DOMAIN=None,
                    ANALYTICAL_DOMAIN=None)

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -130,17 +130,17 @@ ga('send', 'pageview');""" in r, r)
         context = Context()
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
 
-    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES=0)
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=0)
     def test_set_session_cookie_timeout_min(self):
         r = GoogleAnalyticsJsNode().render(Context())
         self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires'; 0});" in r, r)
 
-    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES='10000')
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION='10000')
     def test_set_session_cookie_timeout_as_string(self):
         r = GoogleAnalyticsJsNode().render(Context())
         self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires': 10000});" in r, r)
 
-    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES=-1)
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRATION=-1)
     def test_exception_when_set_session_cookie_timeout_too_small(self):
         context = Context()
         self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)

--- a/analytical/tests/test_tag_google_analytics_js.py
+++ b/analytical/tests/test_tag_google_analytics_js.py
@@ -1,0 +1,156 @@
+"""
+Tests for the Google Analytics template tags and filters, using the new analytics.js library.
+"""
+
+from django.http import HttpRequest
+from django.template import Context
+from django.test.utils import override_settings
+
+from analytical.templatetags.google_analytics_js import GoogleAnalyticsJsNode, \
+    TRACK_SINGLE_DOMAIN, TRACK_MULTIPLE_DOMAINS, TRACK_MULTIPLE_SUBDOMAINS
+from analytical.tests.utils import TestCase, TagTestCase
+from analytical.utils import AnalyticalException
+
+
+@override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
+                   GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_SINGLE_DOMAIN)
+class GoogleAnalyticsTagTestCase(TagTestCase):
+    """
+    Tests for the ``google_analytics_js`` template tag.
+    """
+
+    def test_tag(self):
+        r = self.render_tag('google_analytics_js', 'google_analytics_js')
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
+        self.assertTrue("ga('send', 'pageview');" in r, r)
+
+    def test_node(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {});" in r, r)
+        self.assertTrue("ga('send', 'pageview');" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID=None)
+    def test_no_property_id(self):
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
+
+    @override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='wrong')
+    def test_wrong_property_id(self):
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode)
+
+    @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_SUBDOMAINS,
+                       GOOGLE_ANALYTICS_DOMAIN='example.com')
+    def test_track_multiple_subdomains(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'legacyCookieDomain': 'example.com'}" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
+                       GOOGLE_ANALYTICS_DOMAIN='example.com')
+    def test_track_multiple_domains(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'legacyCookieDomain': 'example.com'," in r, r)
+        self.assertTrue("'allowLinker': true});" in r, r)
+
+    def test_custom_vars(self):
+        context = Context({
+            'google_analytics_var1': ('test1', 'foo'),
+            'google_analytics_var2': ('test2', 'bar'),
+            'google_analytics_var4': ('test4', 'baz'),
+            'google_analytics_var5': ('test5', 'qux'),
+        })
+        r = GoogleAnalyticsJsNode().render(context)
+        self.assertTrue("ga('set', 'test1', 'foo');" in r, r)
+        self.assertTrue("ga('set', 'test2', 'bar');" in r, r)
+        self.assertTrue("ga('set', 'test4', 'baz');" in r, r)
+        self.assertTrue("ga('set', 'test5', 'qux');" in r, r)
+
+    def test_display_advertising(self):
+        with override_settings(GOOGLE_ANALYTICS_DISPLAY_ADVERTISING=True):
+            r = GoogleAnalyticsJsNode().render(Context())
+            self.assertTrue("""ga('create', 'UA-123456-7', 'auto', {});
+ga('require', 'displayfeatures');
+ga('send', 'pageview');""" in r, r)
+
+    @override_settings(ANALYTICAL_INTERNAL_IPS=['1.1.1.1'])
+    def test_render_internal_ip(self):
+        req = HttpRequest()
+        req.META['REMOTE_ADDR'] = '1.1.1.1'
+        context = Context({'request': req})
+        r = GoogleAnalyticsJsNode().render(context)
+        self.assertTrue(r.startswith(
+            '<!-- Google Analytics disabled on internal IP address'), r)
+        self.assertTrue(r.endswith('-->'), r)
+
+    @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=True)
+    def test_anonymize_ip(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('set', 'anonymizeIp', true);" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_ANONYMIZE_IP=False)
+    def test_anonymize_ip_not_present(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertFalse("ga('set', 'anonymizeIp', true);" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=0.0)
+    def test_set_sample_rate_min(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'sampleRate', 0});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE='100.00')
+    def test_set_sample_rate_max(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'sampleRate', 100});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=-1)
+    def test_exception_whenset_sample_rate_too_small(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+
+    @override_settings(GOOGLE_ANALYTICS_SAMPLE_RATE=101)
+    def test_exception_when_set_sample_rate_too_large(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+
+    @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=0.0)
+    def test_set_site_speed_sample_rate_min(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'siteSpeedSampleRate': 0});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE='100.00')
+    def test_set_site_speed_sample_rate_max(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'siteSpeedSampleRate': 100});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=-1)
+    def test_exception_whenset_site_speed_sample_rate_too_small(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+
+    @override_settings(GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE=101)
+    def test_exception_when_set_site_speed_sample_rate_too_large(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES=0)
+    def test_set_session_cookie_timeout_min(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires'; 0});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES='10000')
+    def test_set_session_cookie_timeout_as_string(self):
+        r = GoogleAnalyticsJsNode().render(Context())
+        self.assertTrue("ga('create', 'UA-123456-7', 'auto', {'cookieExpires': 10000});" in r, r)
+
+    @override_settings(GOOGLE_ANALYTICS_COOKIE_EXPIRES=-1)
+    def test_exception_when_set_session_cookie_timeout_too_small(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)
+
+
+@override_settings(GOOGLE_ANALYTICS_PROPERTY_ID='UA-123456-7',
+                   GOOGLE_ANALYTICS_TRACKING_STYLE=TRACK_MULTIPLE_DOMAINS,
+                   GOOGLE_ANALYTICS_DOMAIN=None,
+                   ANALYTICAL_DOMAIN=None)
+class NoDomainTestCase(TestCase):
+    def test_exception_without_domain(self):
+        context = Context()
+        self.assertRaises(AnalyticalException, GoogleAnalyticsJsNode().render, context)

--- a/docs/services/google_analytics_js.rst
+++ b/docs/services/google_analytics_js.rst
@@ -1,5 +1,5 @@
 ======================================
- Google Analytics (legacy) -- traffic analysis
+ Google Analytics -- traffic analysis
 ======================================
 
 `Google Analytics`_ is the well-known web analytics service from
@@ -15,7 +15,7 @@ features.
 Installation
 ============
 
-To start using the Google Analytics (legacy) integration, you must have installed
+To start using the Google Analytics integration, you must have installed
 the django-analytical package and have added the ``analytical``
 application to :const:`INSTALLED_APPS` in your project
 :file:`settings.py` file. See :doc:`../install` for details.
@@ -26,16 +26,16 @@ templates. This step is only needed if you are not using the generic
 :ref:`google-analytics-configuration`.
 
 The Google Analytics tracking code is inserted into templates using a
-template tag.  Load the :mod:`google_analytics` template tag library and
-insert the :ttag:`google_analytics` tag.  Because every page that you
+template tag.  Load the :mod:`google_analytics_js` template tag library and
+insert the :ttag:`google_analytics_js` tag.  Because every page that you
 want to track must have the tag, it is useful to add it to your base
 template.  Insert the tag at the bottom of the HTML head::
 
-    {% load google_analytics %}
+    {% load google_analytics_js %}
     <html>
     <head>
     ...
-    {% google_analytics %}
+    {% google_analytics_js %}
     </head>
     ...
 
@@ -57,7 +57,7 @@ Setting the property ID
 -----------------------
 
 Every website you track with Google Analytics gets its own property ID,
-and the :ttag:`google_analytics` tag will include it in the rendered
+and the :ttag:`google_analytics_js` tag will include it in the rendered
 Javascript code.  You can find the web property ID on the overview page
 of your account.  Set :const:`GOOGLE_ANALYTICS_PROPERTY_ID` in the
 project :file:`settings.py` file::
@@ -72,7 +72,7 @@ Tracking multiple domains
 
 The default code is suitable for tracking a single domain.  If you track
 multiple domains, set the :const:`GOOGLE_ANALYTICS_TRACKING_STYLE`
-setting to one of the :const:`analytical.templatetags.google_analytics.TRACK_*`
+setting to one of the :const:`analytical.templatetags.google_analytics_js.TRACK_*`
 constants:
 
 =============================  =====  =============================================
@@ -87,7 +87,7 @@ Constant                       Value  Description
 =============================  =====  =============================================
 
 As noted, the default tracking style is
-:const:`~analytical.templatetags.google_analytics.TRACK_SINGLE_DOMAIN`.
+:const:`~analytical.templatetags.google_analytics_js.TRACK_SINGLE_DOMAIN`.
 
 When you track multiple (sub)domains, django-analytical needs to know
 what domain name to pass to Google Analytics.  If you use the contrib
@@ -114,19 +114,6 @@ By default, display advertising features are disabled.
 .. _`Display Advertising features`: https://support.google.com/analytics/answer/3450482
 
 
-Tracking site speed
--------------------
-
-You can view page load times in the `Site Speed report`_ by setting the
-:const:`GOOGLE_ANALYTICS_SITE_SPEED` configuration setting::
-
-    GOOGLE_ANALYTICS_SITE_SPEED = True
-
-By default, page load times are not tracked.
-
-.. _`Site Speed report`: https://support.google.com/analytics/answer/1205784
-
-
 .. _google-analytics-internal-ips:
 
 Internal IP addresses
@@ -149,29 +136,15 @@ Custom variables
 As described in the Google Analytics `custom variables`_ documentation
 page, you can define custom segments.  Using template context variables
 ``google_analytics_var1`` through ``google_analytics_var5``, you can let
-the :ttag:`google_analytics` tag pass custom variables to Google
+the :ttag:`google_analytics_js` tag pass custom variables to Google
 Analytics automatically.  You can set the context variables in your view
 when your render a template containing the tracking code::
 
     context = RequestContext({'google_analytics_var1': ('gender', 'female'),
-                              'google_analytics_var2': ('visit', '1', SCOPE_SESSION)})
+                              'google_analytics_var2': ('visit', 1)})
     return some_template.render(context)
 
-The value of the context variable is a tuple *(name, value, [scope])*.
-The scope parameter is one of the
-:const:`analytical.templatetags.google_analytics.SCOPE_*` constants:
-
-=================  ======  =============================================
-Constant           Value   Description
-=================  ======  =============================================
-``SCOPE_VISITOR``    1     Distinguishes categories of visitors across
-                           multiple sessions.
-``SCOPE_SESSION``    2     Distinguishes different visitor experiences
-                           across sessions.
-``SCOPE_PAGE``       3     Defines page-level activity.
-=================  ======  =============================================
-
-The default scope is :const:`~analytical.templatetags.google_analytics.SCOPE_PAGE`.
+The value of the context variable is a tuple *(name, value)*.
 
 You may want to set custom variables in a context processor that you add
 to the :data:`TEMPLATE_CONTEXT_PROCESSORS` list in :file:`settings.py`::
@@ -186,7 +159,7 @@ Just remember that if you set the same context variable in the
 :class:`~django.template.context.RequestContext` constructor and in a
 context processor, the latter clobbers the former.
 
-.. _`custom variables`: http://code.google.com/apis/analytics/docs/tracking/gaTrackingCustomVariables.html
+.. _`custom variables`: https://developers.google.com/analytics/devguides/collection/upgrade/reference/gajs-analyticsjs#custom-vars
 
 
 .. _google-analytics-anonimyze-ips:
@@ -218,9 +191,9 @@ You can configure the `Sample Rate`_ feature by setting the
     GOOGLE_ANALYTICS_SAMPLE_RATE = 10
 
 The value is a percentage and can be between 0 and 100 and can be a string or
-decimal value of with up to two decimal places.
+integer value.
 
-.. _`Sample Rate`: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration#_setsamplerate
+.. _`Sample Rate`: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#sampleRate
 
 
 .. _google-analytics-site-speed-sample-rate:
@@ -234,36 +207,21 @@ You can configure the `Site Speed Sample Rate`_ feature by setting the
     GOOGLE_ANALYTICS_SITE_SPEED_SAMPLE_RATE = 10
 
 The value is a percentage and can be between 0 and 100 and can be a string or
-decimal value of with up to two decimal places.
+integer value.
 
-.. _`Site Speed Sample Rate`: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration#_setsitespeedsamplerate
+.. _`Site Speed Sample Rate`: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#siteSpeedSampleRate
 
 
-.. _google-analytics-session-cookie-timeout:
+.. _google-analytics-cookie-expiration:
 
-Session Cookie Timeout
+Cookie Expiration
 ----------------------
 
-You can configure the `Session Cookie Timeout`_ feature by setting the
-:const:`GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT` configuration setting::
+You can configure the `Cookie Expiration`_ feature by setting the
+:const:`GOOGLE_ANALYTICS_COOKIE_EXPIRATION` configuration setting::
 
-    GOOGLE_ANALYTICS_SESSION_COOKIE_TIMEOUT = 3600000
+    GOOGLE_ANALYTICS_COOKIE_EXPIRATION = 3600000
 
-The value is the session cookie timeout in milliseconds or 0 to delete the cookie when the browser is closed.
+The value is the cookie expiration in seconds or 0 to delete the cookie when the browser is closed.
 
-.. _`Session Cookie Timeout`: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration#_setsessioncookietimeout
-
-
-.. _google-analytics-visitor-cookie-timeout:
-
-Visitor Cookie Timeout
-----------------------
-
-You can configure the `Visitor Cookie Timeout`_ feature by setting the
-:const:`GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT` configuration setting::
-
-    GOOGLE_ANALYTICS_VISITOR_COOKIE_TIMEOUT = 3600000
-
-The value is the visitor cookie timeout in milliseconds or 0 to delete the cookie when the browser is closed.
-
-.. _`Visitor Cookie Timeout`: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration#_setvisitorcookietimeout
+.. _`Cookie Expiration`: https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiBasicConfiguration#_setsessioncookietimeout

--- a/docs/services/google_analytics_js.rst
+++ b/docs/services/google_analytics_js.rst
@@ -59,10 +59,10 @@ Setting the property ID
 Every website you track with Google Analytics gets its own property ID,
 and the :ttag:`google_analytics_js` tag will include it in the rendered
 Javascript code.  You can find the web property ID on the overview page
-of your account.  Set :const:`GOOGLE_ANALYTICS_PROPERTY_ID` in the
+of your account.  Set :const:`GOOGLE_ANALYTICS_JS_PROPERTY_ID` in the
 project :file:`settings.py` file::
 
-    GOOGLE_ANALYTICS_PROPERTY_ID = 'UA-XXXXXX-X'
+    GOOGLE_ANALYTICS_JS_PROPERTY_ID = 'UA-XXXXXX-X'
 
 If you do not set a property ID, the tracking code will not be rendered.
 


### PR DESCRIPTION
This PR adds the support of the the new [analytics.js](https://developers.google.com/analytics/devguides/collection/analyticsjs/) library from Google.

It provides a new `google_analytics_js` tag, which is included if the `GOOGLE_ANALYTICS_JS_PROPERTY_ID` is set. For backwards compatibility, and since it is intended to completely replace the legacy `ga.js` library, the settings are set using the same `GOOGLE_ANALYTICS_` prefix.